### PR TITLE
Fix: redirect unauthenticated users from / to /auth

### DIFF
--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -1,6 +1,6 @@
 import { Box, CircularProgress } from '@mui/material';
 import { lazy, Suspense, useEffect, useState } from 'react';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import { AppLayout } from '@/components';
 import { useAccessControl } from '@/hooks/useAccessControl';
@@ -69,10 +69,10 @@ const AppRouter = () => {
             element={<VerifyEmail />}
           />
 
-          {!hasOrganization && (
+          {!user && (
             <Route
-              path='*'
-              element={<NotFoundPage />}
+              path='/'
+              element={<Navigate to='/auth' replace />}
             />
           )}
 


### PR DESCRIPTION
## Summary
- Corrige bug onde usuários não logados acessando `/` eram redirecionados para `NotFoundPage`
- Agora redireciona corretamente para `/auth`

## Problema
O bloco condicional `!hasOrganization` renderizava uma rota wildcard `*` que capturava todas as rotas (incluindo `/`) quando o usuário não estava logado, mostrando `NotFoundPage` incorretamente.

## Solução
Substituído o bloco problemático por um redirect específico para `/` quando `!user`, utilizando `<Navigate to='/auth' replace />`.