### PR TITLE
feat: refatoring

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[build]
-  command = "pnpm install && pnpm run build"
-  publish = "dist"
-
-[build.environment]
-  NODE_VERSION = "24.4.1"
-  PNPM_VERSION = "10"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "pnpm install && pnpm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "24.4.1"
+  PNPM_VERSION = "10"

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { createContext } from 'react';
 
 type AuthContextType = {
   user: User | undefined;
+  isAuthLoading: boolean;
   hasOrganization: boolean;
   isOrgAdmin: boolean;
   isPlatformAdmin: boolean;

--- a/src/globals/types/ProcessFlow.ts
+++ b/src/globals/types/ProcessFlow.ts
@@ -25,7 +25,7 @@ export type ProcessFlowStageCard = {
   stageId: string;
   stageInstanceId: string;
   title: string;
-  departments: string[];
+  departments: (string | { _id: string; department_name: string; department_acronym: string })[];
   status: ProcessStageStatus;
   additionalInfo?: string;
   wasAdvanced?: boolean;

--- a/src/hooks/useComponentData.tsx
+++ b/src/hooks/useComponentData.tsx
@@ -107,6 +107,20 @@ export const useDownloadFile = () => {
   });
 };
 
+export const useDownloadZip = () => {
+  return useMutation({
+    mutationFn: async (fileIds: string[]) => {
+      const response = await api.post('/files/download-zip', { fileIds }, { responseType: 'blob' });
+      const url = URL.createObjectURL(new Blob([response.data], { type: 'application/zip' }));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'documentos.zip';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+  });
+};
+
 // ==================== TIMELINE ====================
 export const useTimeline = (context: ComponentContext, filters?: any, enabled = true) => {
   return useQuery({

--- a/src/hooks/useFlowModels.tsx
+++ b/src/hooks/useFlowModels.tsx
@@ -142,8 +142,8 @@ export const useFlowModels = () => {
    * POST /flow-models/:id/duplicate
    * Duplica um modelo existente e retorna o novo modelo.
    */
-  const duplicateFlowModel = useCallback(async (id: string): Promise<FlowModel> => {
-    const response = await api.post<FlowModel>(`/flow-models/${id}/duplicate`);
+  const duplicateFlowModel = useCallback(async (id: string, data?: { name?: string; description?: string }): Promise<FlowModel> => {
+    const response = await api.post<FlowModel>(`/flow-models/${id}/duplicate`, data ?? {});
 
     if (!response.data) {
       throw new Error('Resposta da API vazia ao duplicar modelo de fluxo');

--- a/src/pages/AdminPage/components/GerenciaSection.tsx
+++ b/src/pages/AdminPage/components/GerenciaSection.tsx
@@ -838,7 +838,7 @@ const GerenciaSection = ({ currentTab }: GerenciaSectionProps) => {
                       >
                         Telefone
                       </Typography>
-                      <Typography variant='body2'>{selected.department_phone}</Typography>
+                      <Typography variant='body2'>{selected.department_phone || 'Não mencionado'}</Typography>
                     </Grid>
                     {selected.description && (
                       <Grid size={{ xs: 12, md: 6 }}>

--- a/src/pages/FlowModels/FlowModelsPage.tsx
+++ b/src/pages/FlowModels/FlowModelsPage.tsx
@@ -41,6 +41,7 @@ import { StageCard } from "./components/StageCard";
 import { EditStageModal } from "./components/EditStageModal";
 import { CreateStageModal } from "./components/CreateStageModal";
 import { ConfirmDialog } from "./components/ConfirmDialog";
+import { DuplicateFlowModelModal } from "./components/DuplicateFlowModelModal";
 
 type TabValue = "all" | "system" | "mine";
 
@@ -92,6 +93,9 @@ const FlowModelsPage = () => {
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
   const [deleteModelDialogOpen, setDeleteModelDialogOpen] = useState(false);
+  const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
+  const [duplicateTargetId, setDuplicateTargetId] = useState<string | null>(null);
+  const [duplicateDefaults, setDuplicateDefaults] = useState({ name: '', description: '' });
 
   const {
     search: modelSearch,
@@ -222,7 +226,8 @@ const FlowModelsPage = () => {
   });
 
   const { mutate: duplicateModelMutation, isPending: duplicatingModel } = useMutation({
-    mutationFn: duplicateFlowModel,
+    mutationFn: ({ id, name, description }: { id: string; name: string; description: string }) =>
+      duplicateFlowModel(id, { name, description }),
     onSuccess: (newModel) => {
       queryClient.invalidateQueries({ queryKey: ["fetchFlowModels"] });
       showNotification("Modelo duplicado com sucesso!", "success");
@@ -310,9 +315,20 @@ const FlowModelsPage = () => {
     }
   }, [menuModelId, deleteModelMutation, handleMenuClose]);
 
+  const openDuplicateModal = useCallback((modelId: string) => {
+    const model = flowModels.find((m) => m._id === modelId);
+    if (!model) return;
+    setDuplicateTargetId(modelId);
+    setDuplicateDefaults({
+      name: `${model.name} (Cópia)`,
+      description: model.description || ''
+    });
+    setDuplicateModalOpen(true);
+  }, [flowModels]);
+
   const handleDuplicate = useCallback(() => {
-    if (menuModelId) duplicateModelMutation(menuModelId);
-  }, [menuModelId, duplicateModelMutation]);
+    if (menuModelId) openDuplicateModal(menuModelId);
+  }, [menuModelId, openDuplicateModal]);
 
   const handleEditFlow = useCallback(() => {
     if (!selectedModel) return;
@@ -1007,7 +1023,7 @@ const FlowModelsPage = () => {
                       <Button
                         variant="contained"
                         startIcon={<ContentCopyIcon />}
-                        onClick={() => duplicateModelMutation(selectedModel._id)}
+                        onClick={() => openDuplicateModal(selectedModel._id)}
                         disabled={duplicatingModel}
                         sx={{
                           bgcolor: "#1877F2",
@@ -1227,6 +1243,20 @@ const FlowModelsPage = () => {
         title="Alterações não salvas"
         message="Você está no modo de edição. As alterações não salvas serão perdidas. Deseja continuar?"
       />
+      <DuplicateFlowModelModal
+        open={duplicateModalOpen}
+        onClose={() => { setDuplicateModalOpen(false); setDuplicateTargetId(null); }}
+        defaultName={duplicateDefaults.name}
+        defaultDescription={duplicateDefaults.description}
+        loading={duplicatingModel}
+        onConfirm={(name, description) => {
+          const id = duplicateTargetId || selectedModel?._id;
+          if (id) duplicateModelMutation({ id, name, description });
+          setDuplicateModalOpen(false);
+          setDuplicateTargetId(null);
+        }}
+      />
+
       <ConfirmDialog
         open={deleteModelDialogOpen}
         onClose={() => setDeleteModelDialogOpen(false)}

--- a/src/pages/FlowModels/components/DuplicateFlowModelModal.tsx
+++ b/src/pages/FlowModels/components/DuplicateFlowModelModal.tsx
@@ -1,0 +1,100 @@
+import { Box, Button, Dialog, DialogContent, IconButton, TextField, Typography } from '@mui/material';
+import { Close as CloseIcon } from '@mui/icons-material';
+import { useEffect, useState } from 'react';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (name: string, description: string) => void;
+  defaultName: string;
+  defaultDescription: string;
+  loading?: boolean;
+};
+
+export const DuplicateFlowModelModal = ({ open, onClose, onConfirm, defaultName, defaultDescription, loading = false }: Props) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setName(defaultName);
+      setDescription(defaultDescription);
+    }
+  }, [open, defaultName, defaultDescription]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='sm'
+      PaperProps={{ sx: { borderRadius: 3, boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)', overflow: 'hidden' } }}>
+      <DialogContent sx={{ p: 0 }}>
+        {/* Header */}
+        <Box sx={{ px: 3, py: 2.5, borderBottom: '1px solid #e2e8f0', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
+          <Box>
+            <Typography sx={{ fontWeight: 700, color: '#0f172a', fontSize: '1.25rem' }}>Duplicar Modelo</Typography>
+            <Typography variant='body2' sx={{ color: '#64748b', mt: 0.5 }}>
+              Edite o nome e a descrição do novo modelo antes de duplicar.
+            </Typography>
+          </Box>
+          <IconButton onClick={onClose} size='small' sx={{ color: '#64748b', '&:hover': { bgcolor: '#f1f5f9' } }}>
+            <CloseIcon sx={{ fontSize: 20 }} />
+          </IconButton>
+        </Box>
+
+        {/* Form */}
+        <Box sx={{ p: 3, display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+          <Box>
+            <Typography variant='body2' sx={{ fontWeight: 600, color: '#0f172a', mb: 1, fontSize: '0.875rem' }}>
+              Nome
+            </Typography>
+            <TextField
+              fullWidth
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              variant='outlined'
+              sx={{
+                '& .MuiOutlinedInput-root': {
+                  borderRadius: 2,
+                  '& .MuiOutlinedInput-notchedOutline': { border: '2px solid #e2e8f0' },
+                  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#cbd5e1' },
+                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#1877F2', boxShadow: '0 0 0 3px rgba(24,119,242,0.1)' },
+                }
+              }}
+            />
+          </Box>
+          <Box>
+            <Typography variant='body2' sx={{ fontWeight: 600, color: '#0f172a', mb: 1, fontSize: '0.875rem' }}>
+              Descrição
+            </Typography>
+            <TextField
+              fullWidth
+              multiline
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              variant='outlined'
+              sx={{
+                '& .MuiOutlinedInput-root': {
+                  borderRadius: 2,
+                  '& .MuiOutlinedInput-notchedOutline': { border: '2px solid #e2e8f0' },
+                  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#cbd5e1' },
+                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#1877F2', boxShadow: '0 0 0 3px rgba(24,119,242,0.1)' },
+                }
+              }}
+            />
+          </Box>
+        </Box>
+
+        {/* Footer */}
+        <Box sx={{ px: 3, py: 2, bgcolor: '#f8fafc', borderTop: '1px solid #e2e8f0', display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+          <Button onClick={onClose} variant='outlined'
+            sx={{ textTransform: 'none', fontWeight: 600, borderRadius: 2, borderColor: '#E4E6EB', color: '#212121', '&:hover': { borderColor: '#CBD5E1', bgcolor: '#F8F9FA' } }}>
+            Cancelar
+          </Button>
+          <Button onClick={() => onConfirm(name, description)} variant='contained' disabled={loading || !name.trim()}
+            sx={{ textTransform: 'none', fontWeight: 600, borderRadius: 2, bgcolor: '#1877F2', '&:hover': { bgcolor: '#166fe5' }, '&:disabled': { bgcolor: '#E4E6EB', color: '#8A8D91' } }}>
+            {loading ? 'Duplicando...' : 'Duplicar'}
+          </Button>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/pages/PlanejamentoContratacao/components/PlanejamentoSidebar.tsx
+++ b/src/pages/PlanejamentoContratacao/components/PlanejamentoSidebar.tsx
@@ -155,14 +155,14 @@ export const PlanejamentoSidebar = ({ pendencias, proximosPrazos, loading }: Pro
         </Box>
       </Card>
 
-      {/* Próximos Prazos */}
+      {/* Prazos dos Processos da Gerência */}
       <Card sx={{ border: '1px solid', borderColor: '#e2e8f0', boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)', overflow: 'hidden', backgroundColor: '#ffffff' }}>
         <Box sx={{ px: 3, py: 3, borderBottom: '1px solid #f1f5f9', backgroundColor: '#fafbfc' }}>
           <Typography sx={{ fontWeight: 600, fontSize: '1rem', color: '#0f172a', letterSpacing: '-0.01em' }}>
-            Próximos prazos
+            Prazos dos Processos da Gerência
           </Typography>
           <Typography sx={{ fontSize: '0.8125rem', color: '#64748b', mt: 0.25 }}>
-            Prazos dos processos da gerência
+            Próximos prazos
           </Typography>
         </Box>
 

--- a/src/pages/ProcessoPage/ProcessoPage.tsx
+++ b/src/pages/ProcessoPage/ProcessoPage.tsx
@@ -120,12 +120,12 @@ const ProcessoPage = () => {
           const depts = stage.responsibleDepartments || [];
           if (depts.length > 0) {
             return depts.map(d =>
-              typeof d === 'object' ? `${d.department_acronym} - ${d.department_name}` : d
+              d && typeof d === 'object' ? `${d.department_acronym} - ${d.department_name}` : d || 'Não informado'
             );
           }
           // fallback: gerência criadora
           const creator = flowInstance.process.creatorDepartment;
-          const creatorStr = typeof creator === 'object'
+          const creatorStr = creator && typeof creator === 'object'
             ? `${creator.department_acronym} - ${creator.department_name}`
             : creator || 'Não informado';
           return [creatorStr];

--- a/src/pages/ProcessoPage/components/ActionHistory.tsx
+++ b/src/pages/ProcessoPage/components/ActionHistory.tsx
@@ -18,9 +18,11 @@ import {
   AttachFile as AttachFileIcon,
   Image as ImageIcon,
 } from '@mui/icons-material';
-import { Avatar, Box, Chip, Collapse, Dialog, IconButton, MenuItem, Select, Typography } from '@mui/material';
+import { Avatar, Box, Button, Chip, CircularProgress, Collapse, Dialog, IconButton, MenuItem, Select, Typography } from '@mui/material';
+import { PictureAsPdf as PdfIcon } from '@mui/icons-material';
 import { renderCommentText, type CommentMention } from '@/utils/renderCommentText';
 import { useDownloadFile } from '@/hooks';
+import { api } from '@/services';
 import { ProcessStageModal } from './ProcessStageModal';
 import type { ProcessFlowStageCard } from '@/globals/types';
 
@@ -182,6 +184,22 @@ export const ActionHistory = ({ stageExecutions, snapshotStages, stages, process
   const [limit, setLimit] = useState(10);
   const [collapsed, setCollapsed] = useState(false);
   const [modalStage, setModalStage] = useState<ProcessFlowStageCard | null>(null);
+  const [exportLoading, setExportLoading] = useState(false);
+
+  const handleExportAudit = async () => {
+    setExportLoading(true);
+    try {
+      const response = await api.get(`/flows/instances/${instanceId}/audit-export`, { responseType: 'blob' });
+      const url = URL.createObjectURL(new Blob([response.data], { type: 'application/pdf' }));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `auditoria-${instanceId}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setExportLoading(false);
+    }
+  };
 
   const handleLogClick = (stageId: string) => {
     const stage = stages.find(s => s.stageId === stageId);
@@ -216,9 +234,22 @@ export const ActionHistory = ({ stageExecutions, snapshotStages, stages, process
           <Typography variant='h6' sx={{ fontWeight: 800, color: '#0f172a' }}>Histórico de Ações</Typography>
           {totalItems > 0 && <Chip label={totalItems} size='small' sx={{ bgcolor: '#F1F5F9', color: '#64748b', fontWeight: 700, fontSize: '0.75rem', height: 22 }} />}
         </Box>
-        <IconButton size='small' onClick={() => setCollapsed(v => !v)} sx={{ color: '#64748b' }}>
-          {collapsed ? <ExpandMoreIcon fontSize='small' /> : <ExpandLessIcon fontSize='small' />}
-        </IconButton>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {totalItems > 0 && (
+            <Button
+              variant='outlined'
+              onClick={handleExportAudit}
+              disabled={exportLoading}
+              startIcon={exportLoading ? <CircularProgress size={16} /> : <PdfIcon sx={{ color: '#DC2626' }} />}
+              sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2, borderColor: '#E4E6EB', color: '#64748b', '&:hover': { borderColor: '#DC2626', color: '#DC2626', bgcolor: '#FEF2F2' } }}
+            >
+              {exportLoading ? 'Gerando PDF...' : 'Exportar auditoria'}
+            </Button>
+          )}
+          <IconButton size='small' onClick={() => setCollapsed(v => !v)} sx={{ color: '#64748b' }}>
+            {collapsed ? <ExpandMoreIcon fontSize='small' /> : <ExpandLessIcon fontSize='small' />}
+          </IconButton>
+        </Box>
       </Box>
 
       <Collapse in={!collapsed}>

--- a/src/pages/ProcessoPage/components/EditProcessModal.tsx
+++ b/src/pages/ProcessoPage/components/EditProcessModal.tsx
@@ -137,7 +137,7 @@ export const EditProcessModal = ({ open, onClose, flowInstance, initialTab = 0 }
     });
 
   const getSelectedDepts = (stage: FlowInstance['snapshotStages'][0]) =>
-    (stage.responsibleDepartments || []).map(d => d && typeof d === 'object' ? d._id : d).filter(Boolean);
+    (stage.responsibleDepartments || []).map(d => d && typeof d === 'object' ? (d as any)._id : d).filter((id): id is string => !!id);
 
   const handleToggleDept = (stageId: string, deptId: string, current: string[]) => {
     const next = current.includes(deptId) ? current.filter(id => id !== deptId) : [...current, deptId];

--- a/src/pages/ProcessoPage/components/EditProcessModal.tsx
+++ b/src/pages/ProcessoPage/components/EditProcessModal.tsx
@@ -137,7 +137,7 @@ export const EditProcessModal = ({ open, onClose, flowInstance, initialTab = 0 }
     });
 
   const getSelectedDepts = (stage: FlowInstance['snapshotStages'][0]) =>
-    (stage.responsibleDepartments || []).map(d => typeof d === 'object' ? d._id : d);
+    (stage.responsibleDepartments || []).map(d => d && typeof d === 'object' ? d._id : d).filter(Boolean);
 
   const handleToggleDept = (stageId: string, deptId: string, current: string[]) => {
     const next = current.includes(deptId) ? current.filter(id => id !== deptId) : [...current, deptId];
@@ -302,7 +302,7 @@ export const EditProcessModal = ({ open, onClose, flowInstance, initialTab = 0 }
             <Autocomplete
               multiple
               options={(departments as Dept[]).filter(d => {
-                const creatorId = typeof p.creatorDepartment === 'object' ? p.creatorDepartment._id : p.creatorDepartment;
+                const creatorId = p.creatorDepartment && typeof p.creatorDepartment === 'object' ? p.creatorDepartment._id : p.creatorDepartment;
                 return d._id !== creatorId;
               })}
               getOptionLabel={d => `${d.department_acronym} - ${d.department_name}`}
@@ -323,7 +323,7 @@ export const EditProcessModal = ({ open, onClose, flowInstance, initialTab = 0 }
             <Autocomplete
               multiple
               options={users.filter(u => {
-                const createdById = typeof p.createdBy === 'object' ? p.createdBy._id : p.createdBy;
+                const createdById = p.createdBy && typeof p.createdBy === 'object' ? p.createdBy._id : p.createdBy;
                 return u._id !== createdById;
               })}
               getOptionLabel={u => `${u.firstName} ${u.lastName}`}

--- a/src/pages/ProcessoPage/components/ProcessDeadlinesModal.tsx
+++ b/src/pages/ProcessoPage/components/ProcessDeadlinesModal.tsx
@@ -4,7 +4,7 @@ import { Close as CloseIcon, Schedule as ScheduleIcon, CheckCircle as CheckCircl
 type Stage = {
   title: string;
   status: 'completed' | 'in_progress' | 'pending';
-  departments: string[];
+  departments: (string | { _id: string; department_name: string; department_acronym: string })[];
   order: number;
   startedAt?: string;
   completedAt?: string;
@@ -97,7 +97,7 @@ export const ProcessDeadlinesModal = ({ open, onClose, stages, completedCount }:
                 </Box>
                 <Typography sx={{ fontWeight: 700, color: '#0f172a', fontSize: '0.875rem' }}>{stage.title}</Typography>
               </Box>
-              <Typography sx={{ color: '#64748b', fontSize: '0.8rem', fontWeight: 600 }}>{stage.departments.join(' • ') || '—'}</Typography>
+              <Typography sx={{ color: '#64748b', fontSize: '0.8rem', fontWeight: 600 }}>{stage.departments.map(d => typeof d === 'object' ? `${d.department_acronym} - ${d.department_name}` : d).join(' • ') || '—'}</Typography>
               <Typography sx={{ color: '#64748b', fontSize: '0.8rem' }}>{fmt(stage.startedAt)}</Typography>
               <Typography sx={{ color: '#64748b', fontSize: '0.8rem' }}>{fmt(getEffectiveDueDate(stage))}</Typography>
               <Typography sx={{ color: '#64748b', fontSize: '0.8rem' }}>

--- a/src/pages/ProcessoPage/components/ProcessInfoCards.tsx
+++ b/src/pages/ProcessoPage/components/ProcessInfoCards.tsx
@@ -11,7 +11,7 @@ type Props = {
   stages: Array<{
     title: string;
     status: 'completed' | 'in_progress' | 'pending';
-    departments: string[];
+    departments: (string | { _id: string; department_name: string; department_acronym: string })[];
     order: number;
     startedAt?: string;
     completedAt?: string;

--- a/src/pages/ProcessoPage/components/ProcessPendenciesModal.tsx
+++ b/src/pages/ProcessoPage/components/ProcessPendenciesModal.tsx
@@ -5,7 +5,7 @@ import type { FlowInstance } from '@/hooks/useFlowInstance';
 type Stage = {
   title: string;
   status: 'completed' | 'in_progress' | 'pending';
-  departments: string[];
+  departments: (string | { _id: string; department_name: string; department_acronym: string })[];
   order: number;
   dueDate?: string;
   startedAt?: string;
@@ -117,7 +117,7 @@ export const ProcessPendenciesModal = ({ open, onClose, stages }: Props) => {
                         {stage.title}
                       </Typography>
                       <Typography variant='caption' sx={{ color: '#64748b', fontWeight: 600 }}>
-                        {stage.departments.join(' • ') || '—'}
+                        {stage.departments.map(d => typeof d === 'object' ? `${d.department_acronym} - ${d.department_name}` : d).join(' • ') || '—'}
                       </Typography>
                     </Box>
                   </Box>

--- a/src/pages/ProcessoPage/components/ProcessStageCard.tsx
+++ b/src/pages/ProcessoPage/components/ProcessStageCard.tsx
@@ -17,7 +17,7 @@ export type StageStatus = 'completed' | 'in_progress' | 'pending';
 export type ProcessStageProps = {
   order: number;
   title: string;
-  departments: string[];
+  departments: (string | { _id: string; department_name: string; department_acronym: string })[];
   status: StageStatus;
   additionalInfo?: string;
   onClick?: () => void;
@@ -141,11 +141,14 @@ export const ProcessStageCard = ({ order, title, departments, status, additional
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 0.5 }}>
             <BusinessCenterIcon sx={{ fontSize: 16, color: '#64748b', mt: '2px', flexShrink: 0 }} />
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-              {departments.map((dept, i) => (
-                <Typography key={i} variant='body2' sx={{ color: '#475569', fontWeight: 600 }}>
-                  {dept}{i < departments.length - 1 ? ' •' : ''}
-                </Typography>
-              ))}
+              {departments.map((dept, i) => {
+                const label = typeof dept === 'object' ? `${dept.department_acronym} - ${dept.department_name}` : dept;
+                return (
+                  <Typography key={i} variant='body2' sx={{ color: '#475569', fontWeight: 600 }}>
+                    {label}{i < departments.length - 1 ? ' •' : ''}
+                  </Typography>
+                );
+              })}
             </Box>
           </Box>
           {additionalInfo && (

--- a/src/pages/ProcessoPage/components/ProcessoInfoModal.tsx
+++ b/src/pages/ProcessoPage/components/ProcessoInfoModal.tsx
@@ -30,12 +30,12 @@ export const ProcessoInfoModal = ({ open, onClose, flowInstance, currentStage }:
   const formatDate = (d?: string) => d ? new Date(d).toLocaleDateString('pt-BR') : '—';
 
   const creatorDept = p.creatorDepartment && typeof p.creatorDepartment === 'object'
-    ? `${p.creatorDepartment.department_acronym} - ${p.creatorDepartment.department_name}`
-    : p.creatorDepartment || '—';
+    ? `${(p.creatorDepartment as any).department_acronym} - ${(p.creatorDepartment as any).department_name}`
+    : (p.creatorDepartment as string) || '—';
 
   const createdByName = p.createdBy && typeof p.createdBy === 'object'
-    ? `${p.createdBy.firstName} ${p.createdBy.lastName}`
-    : p.createdBy || '—';
+    ? `${(p.createdBy as any).firstName} ${(p.createdBy as any).lastName}`
+    : (p.createdBy as string) || '—';
 
   const participatingDepts = p.participatingDepartments?.length
     ? p.participatingDepartments.map(d =>

--- a/src/pages/ProcessoPage/components/ProcessoInfoModal.tsx
+++ b/src/pages/ProcessoPage/components/ProcessoInfoModal.tsx
@@ -29,17 +29,17 @@ export const ProcessoInfoModal = ({ open, onClose, flowInstance, currentStage }:
 
   const formatDate = (d?: string) => d ? new Date(d).toLocaleDateString('pt-BR') : '—';
 
-  const creatorDept = typeof p.creatorDepartment === 'object'
+  const creatorDept = p.creatorDepartment && typeof p.creatorDepartment === 'object'
     ? `${p.creatorDepartment.department_acronym} - ${p.creatorDepartment.department_name}`
     : p.creatorDepartment || '—';
 
-  const createdByName = typeof p.createdBy === 'object'
+  const createdByName = p.createdBy && typeof p.createdBy === 'object'
     ? `${p.createdBy.firstName} ${p.createdBy.lastName}`
     : p.createdBy || '—';
 
   const participatingDepts = p.participatingDepartments?.length
     ? p.participatingDepartments.map(d =>
-        typeof d === 'object' ? `${d.department_acronym} - ${d.department_name}` : d
+        d && typeof d === 'object' ? `${d.department_acronym} - ${d.department_name}` : d || '—'
       ).join(' • ')
     : '—';
 

--- a/src/pages/ProcessoPage/components/RelatedDocuments.tsx
+++ b/src/pages/ProcessoPage/components/RelatedDocuments.tsx
@@ -8,9 +8,10 @@ import {
   CheckCircle as CheckCircleIcon,
   Schedule as ScheduleIcon,
   Cancel as CancelIcon,
+  FolderZip as FolderZipIcon,
 } from '@mui/icons-material';
-import { Box, Chip, CircularProgress, Collapse, IconButton, Tooltip, Typography } from '@mui/material';
-import { useFilesByProcess, useDownloadFile } from '@/hooks';
+import { Box, Button, Checkbox, Chip, CircularProgress, Collapse, IconButton, Tooltip, Typography } from '@mui/material';
+import { useFilesByProcess, useDownloadFile, useDownloadZip } from '@/hooks';
 
 type RelatedDocumentsProps = {
   processId: string;
@@ -26,21 +27,30 @@ const getStatusChip = (status?: string) => {
 export const RelatedDocuments = ({ processId }: RelatedDocumentsProps) => {
   const { data, isLoading } = useFilesByProcess(processId);
   const downloadMutation = useDownloadFile();
+  const downloadZipMutation = useDownloadZip();
   const [collapsed, setCollapsed] = useState(false);
   const [expandedStages, setExpandedStages] = useState<Record<string, boolean>>({});
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
   const handleDownload = async (fileId: string, inline: boolean) => {
     const result = await downloadMutation.mutateAsync({ fileId, inline });
     if (result?.signedUrl) window.open(result.signedUrl, '_blank');
   };
 
-  const toggleStage = (stageId: string) => {
+  const toggleStage = (stageId: string) =>
     setExpandedStages(prev => ({ ...prev, [stageId]: !prev[stageId] }));
-  };
 
-  // data é um array de grupos: [{ stageId, stageName, stageOrder, files: [...] }]
+  const toggleSelect = (fileId: string) =>
+    setSelectedIds(prev => prev.includes(fileId) ? prev.filter(id => id !== fileId) : [...prev, fileId]);
+
   const groups: any[] = Array.isArray(data) ? data : [];
   const totalFiles = groups.reduce((acc, g) => acc + (g.files?.length || 0), 0);
+  const allFileIds = groups.flatMap(g => g.files?.map((f: any) => f._id) || []);
+  const allSelected = allFileIds.length > 0 && allFileIds.every(id => selectedIds.includes(id));
+  const someSelected = selectedIds.length > 0 && !allSelected;
+
+  const toggleSelectAll = () =>
+    setSelectedIds(allSelected ? [] : allFileIds);
 
   return (
     <Box sx={{ mb: 6 }}>
@@ -54,9 +64,23 @@ export const RelatedDocuments = ({ processId }: RelatedDocumentsProps) => {
             <Chip label={totalFiles} size='small' sx={{ bgcolor: '#F1F5F9', color: '#64748b', fontWeight: 700, fontSize: '0.75rem', height: 22 }} />
           )}
         </Box>
-        <IconButton size='small' onClick={() => setCollapsed(v => !v)} sx={{ color: '#64748b' }}>
-          {collapsed ? <ExpandMoreIcon fontSize='small' /> : <ExpandLessIcon fontSize='small' />}
-        </IconButton>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {selectedIds.length > 0 && (
+            <Button
+              size='small'
+              variant='contained'
+              startIcon={downloadZipMutation.isPending ? <CircularProgress size={14} sx={{ color: '#fff' }} /> : <FolderZipIcon sx={{ fontSize: 16 }} />}
+              onClick={() => downloadZipMutation.mutate(selectedIds)}
+              disabled={downloadZipMutation.isPending}
+              sx={{ bgcolor: '#1877F2', textTransform: 'none', fontWeight: 700, borderRadius: 2, fontSize: '0.8rem', '&:hover': { bgcolor: '#166FE5' } }}
+            >
+              {downloadZipMutation.isPending ? 'Baixando...' : `Baixar ZIP (${selectedIds.length})`}
+            </Button>
+          )}
+          <IconButton size='small' onClick={() => setCollapsed(v => !v)} sx={{ color: '#64748b' }}>
+            {collapsed ? <ExpandMoreIcon fontSize='small' /> : <ExpandLessIcon fontSize='small' />}
+          </IconButton>
+        </Box>
       </Box>
 
       <Collapse in={!collapsed}>
@@ -71,81 +95,103 @@ export const RelatedDocuments = ({ processId }: RelatedDocumentsProps) => {
             </Typography>
           </Box>
         ) : (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {groups
-              .filter(g => g.files?.length > 0)
-              .sort((a, b) => (a.stageOrder ?? 0) - (b.stageOrder ?? 0))
-              .map((group) => {
-                const isExpanded = expandedStages[group.stageId] !== false; // default aberto
-                return (
-                  <Box key={group.stageId} sx={{ border: '1px solid #E4E6EB', borderRadius: 2, overflow: 'hidden', bgcolor: '#fff' }}>
-                    {/* Header do grupo */}
-                    <Box
-                      onClick={() => toggleStage(group.stageId)}
-                      sx={{ px: 2.5, py: 1.5, bgcolor: '#F8FAFC', borderBottom: isExpanded ? '1px solid #E4E6EB' : 'none', display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', '&:hover': { bgcolor: '#F1F5F9' } }}
-                    >
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                        <Typography sx={{ fontWeight: 700, color: '#0f172a', fontSize: '0.9rem' }}>
-                          {group.stageName || `Etapa ${group.stageOrder}`}
-                        </Typography>
-                        <Chip label={`${group.files.length} arquivo${group.files.length !== 1 ? 's' : ''}`} size='small'
-                          sx={{ bgcolor: '#E7F3FF', color: '#1877F2', fontWeight: 700, fontSize: '0.7rem', height: 20 }} />
-                      </Box>
-                      <IconButton size='small' sx={{ color: '#64748b' }}>
-                        {isExpanded ? <ExpandLessIcon fontSize='small' /> : <ExpandMoreIcon fontSize='small' />}
-                      </IconButton>
-                    </Box>
+          <>
+            {/* Barra de seleção global */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5, px: 0.5 }}>
+              <Checkbox
+                checked={allSelected}
+                indeterminate={someSelected}
+                onChange={toggleSelectAll}
+                size='small'
+                sx={{ color: '#CBD5E1', '&.Mui-checked': { color: '#1877F2' }, '&.MuiCheckbox-indeterminate': { color: '#1877F2' }, p: 0.5 }}
+              />
+              <Typography variant='body2' sx={{ color: '#64748b', fontSize: '0.8rem' }}>
+                {someSelected || allSelected ? `${selectedIds.length} selecionado${selectedIds.length !== 1 ? 's' : ''}` : 'Selecionar todos'}
+              </Typography>
+            </Box>
 
-                    {/* Arquivos */}
-                    <Collapse in={isExpanded}>
-                      <Box>
-                        {group.files.map((file: any, idx: number) => {
-                          const status = getStatusChip(file.status);
-                          return (
-                            <Box key={file._id}
-                              sx={{ px: 2.5, py: 1.5, display: 'flex', alignItems: 'center', gap: 1.5, borderBottom: idx < group.files.length - 1 ? '1px solid #F1F5F9' : 'none', '&:hover': { bgcolor: '#F8FAFC' } }}>
-                              <Box sx={{ width: 36, height: 36, borderRadius: 2, bgcolor: '#E7F3FF', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-                                <DescriptionIcon sx={{ color: '#1877F2', fontSize: 20 }} />
-                              </Box>
-                              <Box sx={{ flex: 1, minWidth: 0 }}>
-                                <Typography sx={{ fontWeight: 700, color: '#0f172a', fontSize: '0.875rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                  {file.fileName}
-                                </Typography>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
-                                  {file.version && <Chip label={`v${file.version}`} size='small' sx={{ bgcolor: '#E7F3FF', color: '#1877F2', fontWeight: 700, fontSize: '0.7rem', height: 18 }} />}
-                                  {file.category && <Chip label={file.category} size='small' sx={{ bgcolor: '#ECFDF3', color: '#065F46', fontWeight: 700, fontSize: '0.7rem', height: 18 }} />}
-                                  <Chip icon={status.icon as any} label={status.label} size='small'
-                                    sx={{ bgcolor: status.bg, color: status.color, fontWeight: 700, fontSize: '0.7rem', height: 18, '& .MuiChip-icon': { color: status.color } }} />
-                                  {file.uploadedBy && (
-                                    <Typography variant='caption' sx={{ color: '#94a3b8' }}>
-                                      {file.uploadedBy.firstName} {file.uploadedBy.lastName}
-                                    </Typography>
-                                  )}
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {groups
+                .filter(g => g.files?.length > 0)
+                .sort((a, b) => (a.stageOrder ?? 0) - (b.stageOrder ?? 0))
+                .map((group) => {
+                  const isExpanded = expandedStages[group.stageId] !== false;
+                  return (
+                    <Box key={group.stageId} sx={{ border: '1px solid #E4E6EB', borderRadius: 2, overflow: 'hidden', bgcolor: '#fff' }}>
+                      <Box
+                        onClick={() => toggleStage(group.stageId)}
+                        sx={{ px: 2.5, py: 1.5, bgcolor: '#F8FAFC', borderBottom: isExpanded ? '1px solid #E4E6EB' : 'none', display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', '&:hover': { bgcolor: '#F1F5F9' } }}
+                      >
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                          <Typography sx={{ fontWeight: 700, color: '#0f172a', fontSize: '0.9rem' }}>
+                            {group.stageName || `Etapa ${group.stageOrder}`}
+                          </Typography>
+                          <Chip label={`${group.files.length} arquivo${group.files.length !== 1 ? 's' : ''}`} size='small'
+                            sx={{ bgcolor: '#E7F3FF', color: '#1877F2', fontWeight: 700, fontSize: '0.7rem', height: 20 }} />
+                        </Box>
+                        <IconButton size='small' sx={{ color: '#64748b' }}>
+                          {isExpanded ? <ExpandLessIcon fontSize='small' /> : <ExpandMoreIcon fontSize='small' />}
+                        </IconButton>
+                      </Box>
+
+                      <Collapse in={isExpanded}>
+                        <Box>
+                          {group.files.map((file: any, idx: number) => {
+                            const status = getStatusChip(file.status);
+                            const isSelected = selectedIds.includes(file._id);
+                            return (
+                              <Box key={file._id}
+                                sx={{ px: 2.5, py: 1.5, display: 'flex', alignItems: 'center', gap: 1.5, bgcolor: isSelected ? '#EFF6FF' : 'transparent', borderBottom: idx < group.files.length - 1 ? '1px solid #F1F5F9' : 'none', '&:hover': { bgcolor: isSelected ? '#EFF6FF' : '#F8FAFC' } }}>
+                                <Checkbox
+                                  checked={isSelected}
+                                  onChange={() => toggleSelect(file._id)}
+                                  size='small'
+                                  onClick={e => e.stopPropagation()}
+                                  sx={{ color: '#CBD5E1', '&.Mui-checked': { color: '#1877F2' }, p: 0.5, flexShrink: 0 }}
+                                />
+                                <Box sx={{ width: 36, height: 36, borderRadius: 2, bgcolor: '#E7F3FF', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                                  <DescriptionIcon sx={{ color: '#1877F2', fontSize: 20 }} />
+                                </Box>
+                                <Box sx={{ flex: 1, minWidth: 0 }}>
+                                  <Typography sx={{ fontWeight: 700, color: '#0f172a', fontSize: '0.875rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                    {file.fileName}
+                                  </Typography>
+                                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
+                                    {file.version && <Chip label={`v${file.version}`} size='small' sx={{ bgcolor: '#E7F3FF', color: '#1877F2', fontWeight: 700, fontSize: '0.7rem', height: 18 }} />}
+                                    {file.category && <Chip label={file.category} size='small' sx={{ bgcolor: '#ECFDF3', color: '#065F46', fontWeight: 700, fontSize: '0.7rem', height: 18 }} />}
+                                    <Chip icon={status.icon as any} label={status.label} size='small'
+                                      sx={{ bgcolor: status.bg, color: status.color, fontWeight: 700, fontSize: '0.7rem', height: 18, '& .MuiChip-icon': { color: status.color } }} />
+                                    {file.uploadedBy && (
+                                      <Typography variant='caption' sx={{ color: '#94a3b8' }}>
+                                        {file.uploadedBy.firstName} {file.uploadedBy.lastName}
+                                      </Typography>
+                                    )}
+                                  </Box>
+                                </Box>
+                                <Box sx={{ display: 'flex', gap: 0.5, flexShrink: 0 }}>
+                                  <Tooltip title='Abrir em nova aba'>
+                                    <IconButton size='small' onClick={() => handleDownload(file._id, true)}
+                                      sx={{ border: '1px solid #E4E6EB', borderRadius: 1.5, '&:hover': { borderColor: '#1877F2', bgcolor: '#F0F9FF' } }}>
+                                      <OpenInNewIcon sx={{ fontSize: 16, color: '#1877F2' }} />
+                                    </IconButton>
+                                  </Tooltip>
+                                  <Tooltip title='Baixar'>
+                                    <IconButton size='small' onClick={() => handleDownload(file._id, false)}
+                                      sx={{ border: '1px solid #E4E6EB', borderRadius: 1.5, '&:hover': { borderColor: '#1877F2', bgcolor: '#F0F9FF' } }}>
+                                      <DownloadIcon sx={{ fontSize: 16, color: '#1877F2' }} />
+                                    </IconButton>
+                                  </Tooltip>
                                 </Box>
                               </Box>
-                              <Box sx={{ display: 'flex', gap: 0.5, flexShrink: 0 }}>
-                                <Tooltip title='Abrir em nova aba'>
-                                  <IconButton size='small' onClick={() => handleDownload(file._id, true)}
-                                    sx={{ border: '1px solid #E4E6EB', borderRadius: 1.5, '&:hover': { borderColor: '#1877F2', bgcolor: '#F0F9FF' } }}>
-                                    <OpenInNewIcon sx={{ fontSize: 16, color: '#1877F2' }} />
-                                  </IconButton>
-                                </Tooltip>
-                                <Tooltip title='Baixar'>
-                                  <IconButton size='small' onClick={() => handleDownload(file._id, false)}
-                                    sx={{ border: '1px solid #E4E6EB', borderRadius: 1.5, '&:hover': { borderColor: '#1877F2', bgcolor: '#F0F9FF' } }}>
-                                    <DownloadIcon sx={{ fontSize: 16, color: '#1877F2' }} />
-                                  </IconButton>
-                                </Tooltip>
-                              </Box>
-                            </Box>
-                          );
-                        })}
-                      </Box>
-                    </Collapse>
-                  </Box>
-                );
-              })}
-          </Box>
+                            );
+                          })}
+                        </Box>
+                      </Collapse>
+                    </Box>
+                  );
+                })}
+            </Box>
+          </>
         )}
       </Collapse>
     </Box>

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -5,6 +5,7 @@ import type { AuthResponse, LoginDto, RegisterDto, User } from '@/globals/types'
 import { api } from '@/services';
 import parseJwtToJson from '@/utils/parseJwtToJson';
 import { registerUserUpdatedHandler, unregisterUserUpdatedHandler, reconnectSSE } from '@/hooks/useNotificationSSE';
+import { apiErrorEmitter } from '@/services/apiErrorEmitter';
 
 const authApiPath = '/auth';
 const localStorageUserKey = '@planco:user';
@@ -15,6 +16,7 @@ type Props = {
 
 const AuthProvider = ({ children }: Props) => {
   const [user, setUser] = useState<User | undefined>();
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
   const [hasOrganization, setHasOrganization] = useState(false);
   const [isOrgAdmin, setIsOrgAdmin] = useState(false);
   const [isPlatformAdmin, setIsPlatformAdmin] = useState(false);
@@ -105,46 +107,56 @@ const AuthProvider = ({ children }: Props) => {
     return () => unregisterUserUpdatedHandler();
   }, []);
 
-  const loadUserFromLocalStorage = () => {
-    if (localStorage.getItem(localStorageUserKey)) {
-      const localStorageUser = JSON.parse(String(localStorage.getItem(localStorageUserKey)));
-      verifyAuth(localStorageUser.access_token);
-      if (!user && localStorageUser.access_token) {
-        const decodedJwt = parseJwtToJson(localStorageUser.access_token);
-        if (decodedJwt) {
-          const baseUser = {
-            _id: decodedJwt.sub,
-            firstName: decodedJwt.firstName,
-            lastName: decodedJwt.lastName,
-            email: decodedJwt.email,
-            isPlatformAdmin: decodedJwt.isPlatformAdmin,
-            org: decodedJwt.org,
-            role: decodedJwt.role,
-            departments: decodedJwt.departments
-          };
-          setUser(baseUser);
-          setHasOrganization(decodedJwt.org !== null);
-          api.defaults.headers.common.Authorization = `Bearer ${localStorageUser.access_token}`;
-          // Buscar perfil completo para obter avatarUrl
-          api.get('/users/me').then(res => setUser({ ...baseUser, ...res.data })).catch(() => {});
-        }
-      }
-    }
-  };
+  useEffect(() => {
+    apiErrorEmitter.onUnauthorized(signOut);
+    return () => apiErrorEmitter.offUnauthorized();
+  }, []);
 
   const verifyAuth = (accessToken: string) => {
     const decodedJwt = parseJwtToJson(accessToken);
     if (decodedJwt.exp * 1000 < Date.now()) {
       signOut();
       localStorage.removeItem(localStorageUserKey);
+      return false;
     }
+    return true;
   };
 
-  loadUserFromLocalStorage();
+  useEffect(() => {
+    const localStorageUser = localStorage.getItem(localStorageUserKey);
+    if (localStorageUser) {
+      try {
+        const parsed = JSON.parse(localStorageUser);
+        const isValid = verifyAuth(parsed.access_token);
+        if (isValid && parsed.access_token) {
+          const decodedJwt = parseJwtToJson(parsed.access_token);
+          if (decodedJwt) {
+            const baseUser = {
+              _id: decodedJwt.sub,
+              firstName: decodedJwt.firstName,
+              lastName: decodedJwt.lastName,
+              email: decodedJwt.email,
+              isPlatformAdmin: decodedJwt.isPlatformAdmin,
+              org: decodedJwt.org,
+              role: decodedJwt.role,
+              departments: decodedJwt.departments
+            };
+            setUser(baseUser);
+            setHasOrganization(decodedJwt.org !== null);
+            api.defaults.headers.common.Authorization = `Bearer ${parsed.access_token}`;
+            api.get('/users/me').then(res => setUser({ ...baseUser, ...res.data })).catch(() => {});
+          }
+        }
+      } catch {
+        localStorage.removeItem(localStorageUserKey);
+      }
+    }
+    setIsAuthLoading(false);
+  }, []);
 
   return (
     <AuthContext.Provider
-      value={{ user, signUp, signIn, signOut, refreshToken, updateUser, hasOrganization, isOrgAdmin, isPlatformAdmin }}
+      value={{ user, isAuthLoading, signUp, signIn, signOut, refreshToken, updateUser, hasOrganization, isOrgAdmin, isPlatformAdmin }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -1,5 +1,5 @@
 import { Box, CircularProgress } from '@mui/material';
-import { lazy, Suspense, useMemo } from 'react';
+import { lazy, Suspense, useEffect, useMemo } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import { AppLayout } from '@/components';
@@ -41,12 +41,12 @@ const NAVBAR_DROPDOWN_PREFIXES = [
 ];
 
 // Loading fallback component
-const LoadingFallback = () => (
+const PageLoading = () => (
   <Box
     display='flex'
     justifyContent='center'
     alignItems='center'
-    height='100px'
+    height='100vh'
     width='100%'
   >
     <CircularProgress />
@@ -55,8 +55,12 @@ const LoadingFallback = () => (
 
 const AppRouter = () => {
   const { pathname } = useLocation();
-  const { user, hasOrganization } = useAuth();
+  const { user, hasOrganization, isAuthLoading } = useAuth();
   const { isDesktop } = useScreen();
+
+  useEffect(() => { window.scrollTo(0, 0); }, [pathname]);
+
+  if (isAuthLoading) return <PageLoading />;
 
   // Determina se deve esconder header baseado na rota
   const routeWithoutHeader = useMemo(
@@ -84,7 +88,7 @@ const AppRouter = () => {
       hideSidebar={!hasOrganization || routeWithoutHeader}
       displayNavBarDropdown={displayNavBarDropdown}
     >
-      <Suspense fallback={<LoadingFallback />}>
+      <Suspense fallback={<PageLoading />}>
         <Routes>
           {/* ==================== ROTAS PÚBLICAS ==================== */}
           <Route

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -55,10 +55,51 @@ api.interceptors.request.use(
   }
 );
 
+let isRefreshing = false;
+let refreshQueue: Array<(token: string) => void> = [];
+
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
     const status = error.response?.status;
+    const originalRequest = error.config;
+
+    if (status === 401 && !originalRequest._retry && !originalRequest.url?.includes('/auth/refresh')) {
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          refreshQueue.push((token) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            resolve(api(originalRequest));
+          });
+        });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const userData = localStorage.getItem('@planco:user');
+        const parsed = userData ? JSON.parse(userData) : null;
+        const { data } = await axios.post(
+          `${BASE_URL}/auth/refresh`,
+          {},
+          { headers: { Authorization: `Bearer ${parsed?.access_token}` } }
+        );
+        const newToken = data.access_token;
+        localStorage.setItem('@planco:user', JSON.stringify(data));
+        api.defaults.headers.common.Authorization = `Bearer ${newToken}`;
+        refreshQueue.forEach((cb) => cb(newToken));
+        refreshQueue = [];
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return api(originalRequest);
+      } catch {
+        refreshQueue = [];
+        apiErrorEmitter.emit('__unauthorized__');
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
     const message = Array.isArray(error.response?.data?.message)
       ? error.response.data.message.join(', ')
       : error.response?.data?.message || error.message || 'Erro inesperado';
@@ -66,7 +107,7 @@ api.interceptors.response.use(
     const backendError = new Error(message);
     (backendError as any).status = status;
     (backendError as any).response = error.response;
-    (backendError as any)._emitted = false; // flag para emissão controlada
+    (backendError as any)._emitted = false;
     throw backendError;
   }
 );

--- a/src/services/apiErrorEmitter.ts
+++ b/src/services/apiErrorEmitter.ts
@@ -1,9 +1,18 @@
 type ErrorListener = (message: string) => void;
 
 let listener: ErrorListener | null = null;
+let unauthorizedListener: (() => Promise<void>) | null = null;
 
 export const apiErrorEmitter = {
   subscribe: (fn: ErrorListener) => { listener = fn; },
   unsubscribe: () => { listener = null; },
-  emit: (message: string) => { listener?.(message); },
+  emit: (message: string) => {
+    if (message === '__unauthorized__') {
+      unauthorizedListener?.();
+    } else {
+      listener?.(message);
+    }
+  },
+  onUnauthorized: (fn: () => Promise<void>) => { unauthorizedListener = fn; },
+  offUnauthorized: () => { unauthorizedListener = null; },
 };


### PR DESCRIPTION
Introduce a DuplicateFlowModelModal component and wire it into FlowModelsPage so users can edit name/description before duplicating a flow model. Update duplicateFlowModel API to accept optional name/description. Add useDownloadZip hook (posts to /files/download-zip and triggers ZIP download) and integrate it in RelatedDocuments with per-file selection, select-all checkbox, and a ZIP download button. Also add defensive null checks and user-friendly fallbacks (e.g. 'Não mencionado' / 'Não informado' / '—') in ProcessoPage, EditProcessModal and GerenciaSection, and filter out falsy dept IDs when computing selected departments.