### PR TITLE
feat: add stage rollback and edit model modal

### DIFF
--- a/src/hooks/useFlowInstance.tsx
+++ b/src/hooks/useFlowInstance.tsx
@@ -96,6 +96,19 @@ export const useAdvanceStage = () => {
   });
 };
 
+export const useRollbackStage = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ instanceId, reason }: { instanceId: string; reason: string }) => {
+      const response = await api.post(`/flows/instances/${instanceId}/rollback-stage`, { reason });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['flowInstance'] });
+    }
+  });
+};
+
 export const useUpdateProcess = () => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/pages/FlowModels/FlowModelsPage.tsx
+++ b/src/pages/FlowModels/FlowModelsPage.tsx
@@ -42,6 +42,7 @@ import { EditStageModal } from "./components/EditStageModal";
 import { CreateStageModal } from "./components/CreateStageModal";
 import { ConfirmDialog } from "./components/ConfirmDialog";
 import { DuplicateFlowModelModal } from "./components/DuplicateFlowModelModal";
+import { EditFlowModelModal } from "./components/EditFlowModelModal";
 
 type TabValue = "all" | "system" | "mine";
 
@@ -96,6 +97,9 @@ const FlowModelsPage = () => {
   const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
   const [duplicateTargetId, setDuplicateTargetId] = useState<string | null>(null);
   const [duplicateDefaults, setDuplicateDefaults] = useState({ name: '', description: '' });
+  const [editModelModalOpen, setEditModelModalOpen] = useState(false);
+  const [editModelTargetId, setEditModelTargetId] = useState<string | null>(null);
+  const [editModelDefaults, setEditModelDefaults] = useState({ name: '', description: '' });
 
   const {
     search: modelSearch,
@@ -245,6 +249,21 @@ const FlowModelsPage = () => {
     onError: (error: Error) => showNotification(error?.message || "Erro ao duplicar modelo", "error"),
   });
 
+  const { mutate: editModelAttributesMutation, isPending: editingModelAttributes } = useMutation({
+    mutationFn: ({ id, name, description }: { id: string; name: string; description: string }) =>
+      updateFlowModel(id, { name, description }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fetchFlowModels"] });
+      queryClient.invalidateQueries({ queryKey: ["findFlowModelById", editModelTargetId] });
+      showNotification("Modelo atualizado com sucesso!", "success");
+      setEditModelModalOpen(false);
+      setEditModelTargetId(null);
+      setAnchorEl(null);
+      setMenuModelId(null);
+    },
+    onError: (error: Error) => showNotification(error?.message || "Erro ao atualizar modelo", "error"),
+  });
+
   const handleTabChange = useCallback((_event: React.SyntheticEvent, newValue: TabValue) => {
     const updateTab = () => {
       setSelectedTab(newValue);
@@ -329,6 +348,15 @@ const FlowModelsPage = () => {
   const handleDuplicate = useCallback(() => {
     if (menuModelId) openDuplicateModal(menuModelId);
   }, [menuModelId, openDuplicateModal]);
+
+  const handleOpenEditModelModal = useCallback(() => {
+    if (!menuModelId) return;
+    const model = flowModels.find((m) => m._id === menuModelId);
+    if (!model) return;
+    setEditModelTargetId(menuModelId);
+    setEditModelDefaults({ name: model.name, description: model.description || '' });
+    setEditModelModalOpen(true);
+  }, [menuModelId, flowModels]);
 
   const handleEditFlow = useCallback(() => {
     if (!selectedModel) return;
@@ -1194,6 +1222,13 @@ const FlowModelsPage = () => {
                 </MenuItem>
 
                 {!isSystem && (
+                  <MenuItem onClick={handleOpenEditModelModal} disabled={deletingModel || duplicatingModel}>
+                    <EditIcon sx={{ mr: 1, fontSize: 20 }} />
+                    Editar atributos
+                  </MenuItem>
+                )}
+
+                {!isSystem && (
                   <MenuItem onClick={handleDelete} disabled={deletingModel || duplicatingModel}>
                     <DeleteIcon sx={{ mr: 1, fontSize: 20 }} />
                     {deletingModel ? "Excluindo..." : "Excluir"}
@@ -1254,6 +1289,17 @@ const FlowModelsPage = () => {
           if (id) duplicateModelMutation({ id, name, description });
           setDuplicateModalOpen(false);
           setDuplicateTargetId(null);
+        }}
+      />
+
+      <EditFlowModelModal
+        open={editModelModalOpen}
+        onClose={() => { setEditModelModalOpen(false); setEditModelTargetId(null); }}
+        defaultName={editModelDefaults.name}
+        defaultDescription={editModelDefaults.description}
+        loading={editingModelAttributes}
+        onConfirm={(name, description) => {
+          if (editModelTargetId) editModelAttributesMutation({ id: editModelTargetId, name, description });
         }}
       />
 

--- a/src/pages/FlowModels/components/EditFlowModelModal.tsx
+++ b/src/pages/FlowModels/components/EditFlowModelModal.tsx
@@ -1,0 +1,72 @@
+import { Box, Button, Dialog, DialogContent, IconButton, TextField, Typography } from '@mui/material';
+import { Close as CloseIcon } from '@mui/icons-material';
+import { useEffect, useState } from 'react';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (name: string, description: string) => void;
+  defaultName: string;
+  defaultDescription: string;
+  loading?: boolean;
+};
+
+export const EditFlowModelModal = ({ open, onClose, onConfirm, defaultName, defaultDescription, loading = false }: Props) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setName(defaultName);
+      setDescription(defaultDescription);
+    }
+  }, [open, defaultName, defaultDescription]);
+
+  const fieldSx = {
+    '& .MuiOutlinedInput-root': {
+      borderRadius: 2,
+      '& .MuiOutlinedInput-notchedOutline': { border: '2px solid #e2e8f0' },
+      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#cbd5e1' },
+      '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#1877F2', boxShadow: '0 0 0 3px rgba(24,119,242,0.1)' },
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='sm'
+      PaperProps={{ sx: { borderRadius: 3, boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)', overflow: 'hidden' } }}>
+      <DialogContent sx={{ p: 0 }}>
+        <Box sx={{ px: 3, py: 2.5, borderBottom: '1px solid #e2e8f0', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
+          <Box>
+            <Typography sx={{ fontWeight: 700, color: '#0f172a', fontSize: '1.25rem' }}>Editar Modelo</Typography>
+            <Typography variant='body2' sx={{ color: '#64748b', mt: 0.5 }}>Altere o nome e a descrição do modelo.</Typography>
+          </Box>
+          <IconButton onClick={onClose} size='small' sx={{ color: '#64748b', '&:hover': { bgcolor: '#f1f5f9' } }}>
+            <CloseIcon sx={{ fontSize: 20 }} />
+          </IconButton>
+        </Box>
+
+        <Box sx={{ p: 3, display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+          <Box>
+            <Typography variant='body2' sx={{ fontWeight: 600, color: '#0f172a', mb: 1, fontSize: '0.875rem' }}>Nome</Typography>
+            <TextField fullWidth value={name} onChange={(e) => setName(e.target.value)} variant='outlined' sx={fieldSx} />
+          </Box>
+          <Box>
+            <Typography variant='body2' sx={{ fontWeight: 600, color: '#0f172a', mb: 1, fontSize: '0.875rem' }}>Descrição</Typography>
+            <TextField fullWidth multiline rows={3} value={description} onChange={(e) => setDescription(e.target.value)} variant='outlined' sx={fieldSx} />
+          </Box>
+        </Box>
+
+        <Box sx={{ px: 3, py: 2, bgcolor: '#f8fafc', borderTop: '1px solid #e2e8f0', display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+          <Button onClick={onClose} variant='outlined'
+            sx={{ textTransform: 'none', fontWeight: 600, borderRadius: 2, borderColor: '#E4E6EB', color: '#212121', '&:hover': { borderColor: '#CBD5E1', bgcolor: '#F8F9FA' } }}>
+            Cancelar
+          </Button>
+          <Button onClick={() => onConfirm(name, description)} variant='contained' disabled={loading || !name.trim()}
+            sx={{ textTransform: 'none', fontWeight: 600, borderRadius: 2, bgcolor: '#1877F2', '&:hover': { bgcolor: '#166fe5' }, '&:disabled': { bgcolor: '#E4E6EB', color: '#8A8D91' } }}>
+            {loading ? 'Salvando...' : 'Salvar'}
+          </Button>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/pages/ProcessoPage/ProcessoPage.tsx
+++ b/src/pages/ProcessoPage/ProcessoPage.tsx
@@ -108,7 +108,11 @@ const ProcessoPage = () => {
       }
 
       const advancedLog = execution?.auditLogs?.find((log: any) => log.action === 'ADVANCED');
-      const wasAdvanced = !!advancedLog;
+      const lastRelevantLog = execution?.auditLogs
+        ?.filter((log: any) => log.action === 'ADVANCED' || log.action === 'ROLLED_BACK')
+        .sort((a: any, b: any) => (a.performedAt > b.performedAt ? 1 : -1))
+        .at(-1);
+      const wasAdvanced = !!advancedLog && lastRelevantLog?.action === 'ADVANCED';
 
       return {
         id: stage.stageId,
@@ -191,6 +195,7 @@ const ProcessoPage = () => {
           processId={flowInstance.process._id}
           instanceId={flowInstance._id}
           canAdvance={canAdvance}
+          canRollback={canAdvance}
         />
 
         <RelatedDocuments processId={flowInstance.process._id} />

--- a/src/pages/ProcessoPage/components/ActionHistory.tsx
+++ b/src/pages/ProcessoPage/components/ActionHistory.tsx
@@ -12,6 +12,7 @@ import {
   Event as TimelineIcon,
   BorderColor as SignatureIcon,
   FastForward as AdvancedIcon,
+  ArrowBack as RollbackIcon,
   Group as GroupIcon,
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
@@ -46,6 +47,8 @@ type AuditLog = {
   taskTitle?: string;
   eventTitle?: string;
   signatories?: string[];
+  fromStageName?: string;
+  toStageName?: string;
   [key: string]: any;
 };
 
@@ -89,6 +92,7 @@ const actionConfig: Record<string, { color: string; bg: string; icon: React.Reac
   SIGNATURE_SIGNED:           { color: '#065F46', bg: '#ECFDF3', icon: <SignatureIcon   sx={{ fontSize: 14 }} /> },
   SIGNATURE_SIGNATORIES_SET:  { color: '#1D4ED8', bg: '#EFF6FF', icon: <GroupIcon       sx={{ fontSize: 14 }} /> },
   ADVANCED:                   { color: '#92400E', bg: '#FEF3C7', icon: <AdvancedIcon    sx={{ fontSize: 14 }} /> },
+  ROLLED_BACK:                { color: '#DC2626', bg: '#FEE2E2', icon: <RollbackIcon    sx={{ fontSize: 14 }} /> },
   APPROVED:                   { color: '#065F46', bg: '#ECFDF3', icon: <CheckCircleIcon sx={{ fontSize: 14 }} /> },
 };
 
@@ -113,6 +117,7 @@ const buildDescription = (log: AuditLog): { title: string; detail?: string } => 
     case 'SIGNATURE_SIGNED':        return { title: `Documento assinado${comp ? ` em "${log.componentLabel}"` : ''}` };
     case 'SIGNATURE_SIGNATORIES_SET': return { title: `Signatários definidos${comp ? ` em "${log.componentLabel}"` : ''}`, detail: log.signatories?.join(', ') };
     case 'ADVANCED':                return { title: 'Etapa avançada manualmente', detail: log.reason };
+    case 'ROLLED_BACK':             return { title: `Etapa retrocedida`, detail: `${log.fromStageName ?? ''} → ${log.toStageName ?? ''}${log.reason ? `\n${log.reason}` : ''}` };
     case 'APPROVED':                return { title: 'Etapa aprovada', detail: log.reason };
     default:                        return { title: log.action.replace(/_/g, ' ').toLowerCase(), detail: log.reason };
   }
@@ -130,6 +135,9 @@ const getPerformedBy = (p: PerformedBy) => {
       initials: `${p.firstName?.charAt(0) || ''}${p.lastName?.charAt(0) || ''}`.toUpperCase(),
       avatarUrl: p.avatarUrl ?? undefined,
     };
+  }
+  if (typeof p === 'string' && p) {
+    return { name: `Usuário (${p.slice(-6)})`, initials: '?', avatarUrl: undefined };
   }
   return null;
 };

--- a/src/pages/ProcessoPage/components/ProcessStageCard.tsx
+++ b/src/pages/ProcessoPage/components/ProcessStageCard.tsx
@@ -6,10 +6,11 @@ import {
   PlayArrow as PlayArrowIcon,
   RemoveRedEye as ViewIcon,
   ArrowForward as AdvanceIcon,
+  ArrowBack as RollbackIcon,
   FastForward as FastForwardIcon,
 } from '@mui/icons-material';
 import { Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from '@mui/material';
-import { useAdvanceStage } from '@/hooks/useFlowInstance';
+import { useAdvanceStage, useRollbackStage } from '@/hooks/useFlowInstance';
 import { useNotification } from '@/components/NotificationProvider';
 
 export type StageStatus = 'completed' | 'in_progress' | 'pending';
@@ -22,6 +23,7 @@ export type ProcessStageProps = {
   additionalInfo?: string;
   onClick?: () => void;
   canAdvance?: boolean;
+  canRollback?: boolean;
   instanceId?: string;
   onAdvanced?: () => void;
   wasAdvanced?: boolean;
@@ -30,10 +32,13 @@ export type ProcessStageProps = {
   businessDaysDuration?: number;
 };
 
-export const ProcessStageCard = ({ order, title, departments, status, additionalInfo, onClick, canAdvance, instanceId, onAdvanced, wasAdvanced, dueDate, startedAt, businessDaysDuration }: ProcessStageProps) => {
+export const ProcessStageCard = ({ order, title, departments, status, additionalInfo, onClick, canAdvance, canRollback, instanceId, onAdvanced, wasAdvanced, dueDate, startedAt, businessDaysDuration }: ProcessStageProps) => {
   const [advanceOpen, setAdvanceOpen] = useState(false);
+  const [rollbackOpen, setRollbackOpen] = useState(false);
   const [reason, setReason] = useState('');
+  const [rollbackReason, setRollbackReason] = useState('');
   const advanceMutation = useAdvanceStage();
+  const rollbackMutation = useRollbackStage();
   const { showNotification } = useNotification();
 
   // Calcula se está atrasado
@@ -64,6 +69,22 @@ export const ProcessStageCard = ({ order, title, departments, status, additional
       },
       onError: (err: any) => {
         const msg = err?.response?.data?.message || 'Erro ao avançar etapa';
+        showNotification(Array.isArray(msg) ? msg.join(', ') : msg, 'error');
+      }
+    });
+  };
+
+  const handleRollback = () => {
+    if (!instanceId || !rollbackReason.trim()) return;
+    rollbackMutation.mutate({ instanceId, reason: rollbackReason }, {
+      onSuccess: () => {
+        showNotification('Etapa retrocedida com sucesso!', 'success');
+        setRollbackOpen(false);
+        setRollbackReason('');
+        onAdvanced?.();
+      },
+      onError: (err: any) => {
+        const msg = err?.response?.data?.message || 'Erro ao retroceder etapa';
         showNotification(Array.isArray(msg) ? msg.join(', ') : msg, 'error');
       }
     });
@@ -163,14 +184,47 @@ export const ProcessStageCard = ({ order, title, departments, status, additional
           {btnConfig.text}
         </Button>
 
-        {canAdvance && status === 'in_progress' && (
-          <Button variant='outlined' fullWidth startIcon={<AdvanceIcon sx={{ fontSize: 18 }} />}
-            onClick={() => setAdvanceOpen(true)}
-            sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2, py: 1, borderColor: '#16A34A', color: '#16A34A', '&:hover': { borderColor: '#15803D', bgcolor: '#F0FDF4' } }}>
-            Avançar Etapa
-          </Button>
+        {(canAdvance || canRollback) && status === 'in_progress' && (
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            {canRollback && (
+              <Button variant='outlined' fullWidth startIcon={<RollbackIcon sx={{ fontSize: 18 }} />}
+                onClick={() => setRollbackOpen(true)}
+                sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2, py: 1, borderColor: '#DC2626', color: '#DC2626', '&:hover': { borderColor: '#B91C1C', bgcolor: '#FFF1F2' } }}>
+                Retroceder
+              </Button>
+            )}
+            {canAdvance && (
+              <Button variant='outlined' fullWidth startIcon={<AdvanceIcon sx={{ fontSize: 18 }} />}
+                onClick={() => setAdvanceOpen(true)}
+                sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2, py: 1, borderColor: '#16A34A', color: '#16A34A', '&:hover': { borderColor: '#15803D', bgcolor: '#F0FDF4' } }}>
+                Avançar
+              </Button>
+            )}
+          </Box>
         )}
       </Box>
+
+      <Dialog open={rollbackOpen} onClose={() => { setRollbackOpen(false); setRollbackReason(''); }} maxWidth='xs' fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+        <DialogTitle sx={{ fontWeight: 700, fontSize: '1.1rem', color: '#0f172a' }}>Retroceder Etapa</DialogTitle>
+        <DialogContent>
+          <Typography variant='body2' sx={{ color: '#64748b', mb: 2 }}>
+            Deseja retroceder a etapa <strong>{title}</strong>? A etapa anterior voltará para <strong>Em Andamento</strong>. Informe o motivo obrigatoriamente.
+          </Typography>
+          <TextField fullWidth multiline rows={3} label='Motivo (obrigatório)'
+            value={rollbackReason} onChange={(e) => setRollbackReason(e.target.value)}
+            placeholder='Descreva o motivo para retroceder...' />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => { setRollbackOpen(false); setRollbackReason(''); }} variant='outlined' sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2 }}>
+            Cancelar
+          </Button>
+          <Button onClick={handleRollback} variant='contained' disabled={rollbackMutation.isPending || !rollbackReason.trim()}
+            startIcon={rollbackMutation.isPending ? <CircularProgress size={16} /> : <RollbackIcon />}
+            sx={{ bgcolor: '#DC2626', textTransform: 'none', fontWeight: 700, borderRadius: 2, '&:hover': { bgcolor: '#B91C1C' } }}>
+            {rollbackMutation.isPending ? 'Retrocedendo...' : 'Confirmar'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <Dialog open={advanceOpen} onClose={() => setAdvanceOpen(false)} maxWidth='xs' fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
         <DialogTitle sx={{ fontWeight: 700, fontSize: '1.1rem', color: '#0f172a' }}>Avançar Etapa</DialogTitle>

--- a/src/pages/ProcessoPage/components/ProcessStagesSection.tsx
+++ b/src/pages/ProcessoPage/components/ProcessStagesSection.tsx
@@ -9,9 +9,10 @@ type ProcessStagesSectionProps = {
   processId: string;
   instanceId: string;
   canAdvance?: boolean;
+  canRollback?: boolean;
 };
 
-export const ProcessStagesSection = ({ stages, processId, instanceId, canAdvance }: ProcessStagesSectionProps) => {
+export const ProcessStagesSection = ({ stages, processId, instanceId, canAdvance, canRollback }: ProcessStagesSectionProps) => {
   const [selectedStage, setSelectedStage] = useState<ProcessFlowStageCard | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedStageStatus, setSelectedStageStatus] = useState<'completed' | 'in_progress' | 'pending'>('pending');
@@ -68,6 +69,7 @@ export const ProcessStagesSection = ({ stages, processId, instanceId, canAdvance
             additionalInfo={stage.additionalInfo}
             onClick={() => handleStageClick(stage)}
             canAdvance={canAdvance}
+            canRollback={canRollback}
             instanceId={instanceId}
             onAdvanced={handleCloseModal}
             wasAdvanced={stage.wasAdvanced}


### PR DESCRIPTION
Introduce stage rollback support and a flow-model edit modal. Adds useRollbackStage hook that calls /flows/instances/{id}/rollback-stage and invalidates flowInstance queries. ProcessStageCard now supports rollback (UI button, dialog, mutation) and uses useRollbackStage; history descriptions and actionConfig updated to handle ROLLED_BACK; wasAdvanced logic adjusted to consider the last ADVANCED/ROLLED_BACK audit log. Adds EditFlowModelModal component and integrates it into FlowModelsPage with a mutation to update model attributes and appropriate query invalidation and notifications.