### PR TITLE
feat: show stage statuses/dates & add dashboard pagination

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -69,11 +69,11 @@ const modules: Module[] = [
     path: '/planejamento-da-contratacao',
     description: 'Organize todas as fases da contratação',
     subItems: [
-      { label: 'Painel', icon: <Home sx={{ fontSize: 16 }} />, path: '/planejamento-da-contratacao' },
-      { label: 'Processos', icon: <GroupOutlined sx={{ fontSize: 16 }} />, path: '/processos-gerencia' },
-      { label: 'Modelos de Fluxo', icon: <AccountTreeOutlined sx={{ fontSize: 16 }} />, path: '/modelos-fluxo' },
-      { label: 'Gerenciamento de Pastas', icon: <FolderOutlined sx={{ fontSize: 16 }} />, path: '/gerenciamento-pastas' },
-      { label: 'Insights', icon: <InsightsOutlined sx={{ fontSize: 16 }} />, path: '/insights' },
+      { label: 'Painel', icon: <Home sx={{ fontSize: 30 }} />, path: '/planejamento-da-contratacao' },
+      { label: 'Processos', icon: <GroupOutlined sx={{ fontSize: 30 }} />, path: '/processos-gerencia' },
+      { label: 'Modelos de Fluxo', icon: <AccountTreeOutlined sx={{ fontSize: 30 }} />, path: '/modelos-fluxo' },
+      { label: 'Gerenciamento de Pastas', icon: <FolderOutlined sx={{ fontSize: 30 }} />, path: '/gerenciamento-pastas' },
+      { label: 'Insights', icon: <InsightsOutlined sx={{ fontSize: 30 }} />, path: '/insights' },
     ]
   }
 ];
@@ -336,12 +336,12 @@ const Sidebar = ({ open, onClose }: SidebarProps) => {
                           }
                         }}
                       >
-                        <ListItemIcon sx={{ minWidth: 28, color: isActiveSubItem(sub.path) ? '#2563eb' : '#9ca3af' }}>
+                        <ListItemIcon sx={{ minWidth: 32, color: isActiveSubItem(sub.path) ? '#2563eb' : '#9ca3af' }}>
                           {sub.icon}
                         </ListItemIcon>
                         <ListItemText
                           primary={
-                            <Typography variant='body2' sx={{ fontSize: '0.8125rem', fontWeight: isActiveSubItem(sub.path) ? 600 : 400, lineHeight: 1.3 }}>
+                            <Typography variant='body2' sx={{ fontSize: '0.875rem', fontWeight: isActiveSubItem(sub.path) ? 600 : 400, lineHeight: 1.3 }}>
                               {sub.label}
                             </Typography>
                           }

--- a/src/globals/types/Planejamento.ts
+++ b/src/globals/types/Planejamento.ts
@@ -12,8 +12,10 @@ export type AlertaCritico = {
   processId: string;
   processNumber: string;
   object: string;
-  alertType: 'vencido' | 'assinatura' | 'juridico' | 'outro';
+  alertType: 'vencido' | 'etapa_atrasada' | 'assinatura' | 'juridico' | 'outro';
   description: string;
+  stageName?: string;
+  stageDueDate?: string;
 };
 
 export type ProcessoRecente = {
@@ -21,8 +23,8 @@ export type ProcessoRecente = {
   processNumber: string;
   object: string;
   currentStage: string;
-  status: 'em_dia' | 'atrasado' | 'prazo';
-  daysLate: number;
+  stageStatus: 'em_dia' | 'atrasada' | 'vence_hoje' | 'concluida';
+  processStatus: 'em_andamento' | 'em_risco' | 'atrasado' | 'finalizado' | 'paralisado';
   dueDate: string;
 };
 
@@ -45,10 +47,18 @@ export type ProximoPrazo = {
   date: string;
 };
 
+export type Paginated<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};
+
 export type PlanejamentoDashboardResponse = {
   kpis: PlanejamentoKpis;
-  alertasCriticos: AlertaCritico[];
-  processosRecentes: ProcessoRecente[];
+  alertasCriticos: Paginated<AlertaCritico>;
+  processosRecentes: Paginated<ProcessoRecente>;
   pendencias: Pendencia[];
   proximosPrazos: ProximoPrazo[];
 };

--- a/src/globals/types/Process.ts
+++ b/src/globals/types/Process.ts
@@ -13,6 +13,8 @@ export type Process = {
   modality?: string;
   priority?: 'Baixa' | 'Média' | 'Alta';
   status?: 'Em Andamento' | 'Em Atraso' | 'Concluído' | 'Pendente';
+  stageStatus?: 'em_dia' | 'atrasada' | 'vence_hoje' | 'concluida';
+  stageDueDate?: string | null;
   dueDate?: string;
   estimatedValue?: number;
   folder?:
@@ -25,10 +27,6 @@ export type Process = {
   org?: string;
   createdAt?: string;
   updatedAt?: string;
-  topPendencia?: {
-    type: string | null;
-    label: string;
-  };
 };
 
 export type PaginatedProcesses = {

--- a/src/globals/types/index.ts
+++ b/src/globals/types/index.ts
@@ -35,6 +35,7 @@ export type {
 } from './Notification';
 export type {
   AlertaCritico,
+  Paginated,
   PlanejamentoDashboardResponse,
   PlanejamentoKpis,
   Pendencia,

--- a/src/hooks/usePlanejamentoDashboard.ts
+++ b/src/hooks/usePlanejamentoDashboard.ts
@@ -1,20 +1,36 @@
-import { useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { PlanejamentoDashboardResponse } from '@/globals/types';
 import { api } from '@/services';
 
-export const usePlanejamentoDashboard = (departmentId?: string) => {
-  const fetchDashboard = useCallback(async () => {
-    const response = await api.get<PlanejamentoDashboardResponse>('/planejamento/dashboard', {
-      params: departmentId ? { departmentId } : undefined
-    });
-    return response.data;
-  }, [departmentId]);
+type Params = {
+  departmentId?: string;
+  alertasPage?: number;
+  alertasLimit?: number;
+  recentesPage?: number;
+  recentesLimit?: number;
+};
 
+export const usePlanejamentoDashboard = ({
+  departmentId,
+  alertasPage = 1,
+  alertasLimit = 5,
+  recentesPage = 1,
+  recentesLimit = 5,
+}: Params = {}) => {
   return useQuery({
-    queryKey: ['planejamento-dashboard', departmentId],
-    queryFn: fetchDashboard,
+    queryKey: ['planejamento-dashboard', departmentId, alertasPage, alertasLimit, recentesPage, recentesLimit],
+    queryFn: async () => {
+      const response = await api.get<PlanejamentoDashboardResponse>('/planejamento/dashboard', {
+        params: {
+          ...(departmentId ? { departmentId } : {}),
+          alertasPage,
+          alertasLimit,
+          recentesPage,
+          recentesLimit,
+        },
+      });
+      return response.data;
+    },
     staleTime: 2 * 60 * 1000,
-    enabled: true
   });
 };

--- a/src/pages/FolderProcesses/components/ProcessTable.tsx
+++ b/src/pages/FolderProcesses/components/ProcessTable.tsx
@@ -1,6 +1,7 @@
 import {
   Assignment as AssignmentIcon,
   AttachFile as AttachFileIcon,
+  CalendarToday as CalendarIcon,
   SwapVert as SwapVertIcon,
   Visibility as VisibilityIcon,
   WarningOutlined as WarningIcon
@@ -19,7 +20,15 @@ import {
   Typography
 } from '@mui/material';
 import { useMemo, useState } from 'react';
+import dayjs from 'dayjs';
 import type { Process } from '@/globals/types';
+
+const STAGE_STATUS_CONFIG: Record<string, { label: string; bg: string; color: string; border: string }> = {
+  em_dia:     { label: 'Em dia',     bg: 'rgba(0,110,41,0.05)',   color: '#006e29', border: 'rgba(0,110,41,0.1)' },
+  atrasada:   { label: 'Atrasada',   bg: 'rgba(186,26,26,0.05)',  color: '#ba1a1a', border: 'rgba(186,26,26,0.1)' },
+  vence_hoje: { label: 'Vence hoje', bg: 'rgba(202,138,4,0.08)',  color: '#ca8a04', border: 'rgba(202,138,4,0.15)' },
+  concluida:  { label: 'Concluída',  bg: 'rgba(99,102,241,0.07)', color: '#4f46e5', border: 'rgba(99,102,241,0.15)' },
+};
 
 interface ProcessTableProps {
   processes: Process[];
@@ -276,9 +285,11 @@ export const ProcessTable = ({ processes, onProcessClick }: ProcessTableProps) =
               </TableCell>
               <TableCell sx={{ minWidth: { xs: 200, sm: 300, md: 400, lg: 500 } }}>Objeto</TableCell>
               <TableCell>Etapa Atual</TableCell>
+              <TableCell align='center'>Prazo Final da Etapa</TableCell>
               <TableCell>Modalidade</TableCell>
               <TableCell>Prioridade</TableCell>
               <TableCell>Situação</TableCell>
+              <TableCell align='center'>Prazo Final do Processo</TableCell>
               <TableCell>Visualizar</TableCell>
             </TableRow>
           </TableHead>
@@ -466,6 +477,18 @@ export const ProcessTable = ({ processes, onProcessClick }: ProcessTableProps) =
                       />
                     </Box>
                   </TableCell>
+                  <TableCell align='center'>
+                    {process.stageDueDate ? (
+                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
+                        <CalendarIcon sx={{ fontSize: 16, color: '#8A8D91' }} />
+                        <Typography variant='body2' sx={{ color: '#212121', fontSize: '0.875rem' }}>
+                          {dayjs(process.stageDueDate).format('DD/MM/YYYY')}
+                        </Typography>
+                      </Box>
+                    ) : (
+                      <Typography variant='body2' sx={{ color: '#8A8D91', textAlign: 'center' }}>—</Typography>
+                    )}
+                  </TableCell>
                   <TableCell>
                     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-start' }}>
                       <Chip
@@ -528,67 +551,37 @@ export const ProcessTable = ({ processes, onProcessClick }: ProcessTableProps) =
                   </TableCell>
                   <TableCell>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, justifyContent: 'flex-start' }}>
-                      <Chip
-                        label={process.status || 'N/A'}
-                        size='small'
-                        sx={{
-                          display: 'inline-flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: '0.75rem',
-                          fontWeight: getStatusColor(process.status).fontWeight || 600,
-                          padding: '6px 12px',
-                          borderRadius: '16px',
-                          whiteSpace: 'nowrap',
-                          backgroundColor: '#FFFFFF',
-                          color: getStatusColor(process.status).color,
-                          border: '1px solid #E4E6EB',
-                          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.05)',
-                          height: '28px',
-                          minWidth: 'fit-content',
-                          transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-                          '&:hover': {
-                            borderColor: '#D1D5DB',
-                            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.1)',
-                            transform: 'translateY(-1px)'
-                          }
-                        }}
-                      />
+                      {process.stageStatus ? (
+                        <Chip
+                          label={STAGE_STATUS_CONFIG[process.stageStatus]?.label ?? process.stageStatus}
+                          size='small'
+                          sx={{ fontSize: '0.75rem', fontWeight: 900, borderRadius: '999px', backgroundColor: STAGE_STATUS_CONFIG[process.stageStatus]?.bg, color: STAGE_STATUS_CONFIG[process.stageStatus]?.color, border: `1px solid ${STAGE_STATUS_CONFIG[process.stageStatus]?.border}`, height: '28px' }}
+                        />
+                      ) : (
+                        <Chip
+                          label={process.status || 'N/A'}
+                          size='small'
+                          sx={{ fontSize: '0.75rem', fontWeight: getStatusColor(process.status).fontWeight || 600, borderRadius: '16px', backgroundColor: '#FFFFFF', color: getStatusColor(process.status).color, border: '1px solid #E4E6EB', height: '28px' }}
+                        />
+                      )}
                       {['Em Atraso', 'Atrasado'].includes(process.status || '') && (
-                        <Box
-                          sx={{
-                            width: 28,
-                            height: 28,
-                            borderRadius: '50%',
-                            backgroundColor: 'rgba(184, 30, 52, 0.12)',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            filter: 'drop-shadow(0 2px 3px rgba(184, 30, 52, 0.25))',
-                            animation: 'pulseAlert 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
-                            flexShrink: 0,
-                            border: '1px solid rgba(184, 30, 52, 0.2)',
-                            transition: 'all 0.2s ease',
-                            '&:hover': {
-                              backgroundColor: 'rgba(184, 30, 52, 0.18)',
-                              transform: 'scale(1.05)'
-                            },
-                            '@keyframes pulseAlert': {
-                              '0%, 100%': {
-                                opacity: 1,
-                                transform: 'scale(1)'
-                              },
-                              '50%': {
-                                opacity: 0.8,
-                                transform: 'scale(1.08)'
-                              }
-                            }
-                          }}
-                        >
+                        <Box sx={{ width: 28, height: 28, borderRadius: '50%', backgroundColor: 'rgba(184, 30, 52, 0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, border: '1px solid rgba(184, 30, 52, 0.2)' }}>
                           <WarningIcon sx={{ fontSize: 18, color: '#B81E34' }} />
                         </Box>
                       )}
                     </Box>
+                  </TableCell>
+                  <TableCell align='center'>
+                    {process.dueDate ? (
+                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
+                        <CalendarIcon sx={{ fontSize: 16, color: '#8A8D91' }} />
+                        <Typography variant='body2' sx={{ color: '#212121', fontSize: '0.875rem' }}>
+                          {dayjs(process.dueDate).format('DD/MM/YYYY')}
+                        </Typography>
+                      </Box>
+                    ) : (
+                      <Typography variant='body2' sx={{ color: '#8A8D91', textAlign: 'center' }}>—</Typography>
+                    )}
                   </TableCell>
                   <TableCell>
                     <Box sx={{ display: 'flex', justifyContent: 'flex-start', gap: 0.5, alignItems: 'center' }}>

--- a/src/pages/GerenciaProcesses/GerenciaProcessesPage.tsx
+++ b/src/pages/GerenciaProcesses/GerenciaProcessesPage.tsx
@@ -119,14 +119,6 @@ const GerenciaProcessesPage = () => {
 
     let filtered = processesData.processes;
 
-    // Filtrar por pendência usando topPendencia da API
-    const pendingFilter = urlParams.get('pending');
-    if (pendingFilter === 'yes') {
-      filtered = filtered.filter((process: Process) => process.topPendencia?.type !== null && process.topPendencia?.type !== undefined);
-    } else if (pendingFilter === 'no') {
-      filtered = filtered.filter((process: Process) => !process.topPendencia?.type);
-    }
-
     // Filtrar por data selecionada
     if (selectedDate) {
       filtered = filtered.filter((process: Process) => {

--- a/src/pages/GerenciaProcesses/components/ProcessTable.tsx
+++ b/src/pages/GerenciaProcesses/components/ProcessTable.tsx
@@ -1,15 +1,12 @@
 import {
   Assignment as AssignmentIcon,
   CalendarToday as CalendarIcon,
-  CheckCircle as CheckCircleIcon,
-  Edit as EditIcon,
   SwapVert as SwapVertIcon,
   Visibility as VisibilityIcon,
   Warning as WarningIcon
 } from '@mui/icons-material';
 import {
   Box,
-  Button,
   Chip,
   IconButton,
   Table,
@@ -42,66 +39,11 @@ const getStatusColor = (status?: string) => {
   }
 };
 
-const PendenciaCell = ({ process, onProcessClick }: { process: Process; onProcessClick?: (p: Process) => void }) => {
-  const pendencia = process.topPendencia;
-  const hasPendencia = pendencia?.type !== null && pendencia?.type !== undefined;
-
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-      {hasPendencia ? (
-        <Button
-          size='small'
-          startIcon={<EditIcon />}
-          onClick={() => onProcessClick?.(process)}
-          sx={{
-            textTransform: 'none',
-            fontSize: '0.75rem',
-            fontWeight: 600,
-            px: 1.5,
-            py: 0.5,
-            borderRadius: 2,
-            backgroundColor: '#1877F2',
-            color: '#FFFFFF',
-            '&:hover': { backgroundColor: '#166fe5' }
-          }}
-        >
-          {pendencia?.label ?? 'Pendência'}
-        </Button>
-      ) : (
-        <Chip
-          icon={<CheckCircleIcon sx={{ fontSize: '14px !important', color: '#1F7A37' }} />}
-          label='Sem pendência'
-          size='small'
-          onClick={() => onProcessClick?.(process)}
-          sx={{
-            fontSize: '0.75rem',
-            fontWeight: 600,
-            px: 1,
-            borderRadius: '16px',
-            backgroundColor: '#FFFFFF',
-            color: '#1F7A37',
-            border: '1px solid #E4E6EB',
-            height: '28px',
-            cursor: 'pointer',
-            '&:hover': { backgroundColor: '#E6F4EA', borderColor: '#D1D5DB' }
-          }}
-        />
-      )}
-
-      <Tooltip title='Visualizar processo' arrow placement='top'>
-        <IconButton
-          size='small'
-          onClick={() => onProcessClick?.(process)}
-          sx={{
-            width: 32, height: 32, borderRadius: '50%', color: '#8A8D91',
-            '&:hover': { backgroundColor: 'rgba(24,119,242,0.08)', color: '#1877F2' }
-          }}
-        >
-          <VisibilityIcon sx={{ fontSize: 18 }} />
-        </IconButton>
-      </Tooltip>
-    </Box>
-  );
+const STAGE_STATUS_CONFIG: Record<string, { label: string; bg: string; color: string; border: string }> = {
+  em_dia:     { label: 'Em dia',     bg: 'rgba(0,110,41,0.05)',   color: '#006e29', border: 'rgba(0,110,41,0.1)' },
+  atrasada:   { label: 'Atrasada',   bg: 'rgba(186,26,26,0.05)',  color: '#ba1a1a', border: 'rgba(186,26,26,0.1)' },
+  vence_hoje: { label: 'Vence hoje', bg: 'rgba(202,138,4,0.08)',  color: '#ca8a04', border: 'rgba(202,138,4,0.15)' },
+  concluida:  { label: 'Concluída',  bg: 'rgba(99,102,241,0.07)', color: '#4f46e5', border: 'rgba(99,102,241,0.15)' },
 };
 
 export const ProcessTable = ({ processes, onProcessClick }: ProcessTableProps) => {
@@ -160,9 +102,9 @@ export const ProcessTable = ({ processes, onProcessClick }: ProcessTableProps) =
               </TableCell>
               <TableCell sx={{ minWidth: { xs: 200, md: 400 } }}>Objeto</TableCell>
               <TableCell>Etapa Atual</TableCell>
-              <TableCell>Prazo Final</TableCell>
+              <TableCell align='center'>Prazo Final da Etapa</TableCell>
               <TableCell sx={{ minWidth: 140 }}>Situação</TableCell>
-              <TableCell>Pendências</TableCell>
+              <TableCell align='center'>Prazo Final do Processo</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -216,25 +158,29 @@ export const ProcessTable = ({ processes, onProcessClick }: ProcessTableProps) =
                         sx={{ fontSize: '0.75rem', fontWeight: 600, borderRadius: '20px', backgroundColor: '#FFFFFF', color: '#3A3B3C', border: '1px solid #E4E6EB', height: '28px' }}
                       />
                     </TableCell>
-                    <TableCell>
-                      {process.dueDate ? (
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <TableCell align='center'>
+                      {process.stageDueDate ? (
+                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
                           <CalendarIcon sx={{ fontSize: 16, color: '#8A8D91' }} />
                           <Typography variant='body2' sx={{ color: '#212121' }}>
-                            {dayjs(process.dueDate).format('DD/MM/YYYY')}
+                            {dayjs(process.stageDueDate).format('DD/MM/YYYY')}
                           </Typography>
                         </Box>
                       ) : (
-                        <Typography variant='body2' sx={{ color: '#8A8D91' }}>N/A</Typography>
+                        <Typography variant='body2' sx={{ color: '#8A8D91', textAlign: 'center' }}>—</Typography>
                       )}
                     </TableCell>
                     <TableCell sx={{ minWidth: 140 }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <Chip
-                          label={process.status || 'N/A'}
-                          size='small'
-                          sx={{ fontSize: '0.75rem', fontWeight: statusColor.fontWeight, borderRadius: '16px', backgroundColor: '#FFFFFF', color: statusColor.color, border: '1px solid #E4E6EB', height: '28px' }}
-                        />
+                        {process.stageStatus ? (
+                          <Chip
+                            label={STAGE_STATUS_CONFIG[process.stageStatus]?.label ?? process.stageStatus}
+                            size='small'
+                            sx={{ fontSize: '0.75rem', fontWeight: 900, borderRadius: '999px', backgroundColor: STAGE_STATUS_CONFIG[process.stageStatus]?.bg, color: STAGE_STATUS_CONFIG[process.stageStatus]?.color, border: `1px solid ${STAGE_STATUS_CONFIG[process.stageStatus]?.border}`, height: '28px' }}
+                          />
+                        ) : (
+                          <Chip label={process.status || 'N/A'} size='small' sx={{ fontSize: '0.75rem', fontWeight: statusColor.fontWeight, borderRadius: '16px', backgroundColor: '#FFFFFF', color: statusColor.color, border: '1px solid #E4E6EB', height: '28px' }} />
+                        )}
                         {process.status === 'Em Atraso' && (
                           <Box sx={{ width: 28, height: 28, borderRadius: '50%', backgroundColor: 'rgba(184,30,52,0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid rgba(184,30,52,0.2)' }}>
                             <WarningIcon sx={{ fontSize: 18, color: '#B81E34' }} />
@@ -242,8 +188,17 @@ export const ProcessTable = ({ processes, onProcessClick }: ProcessTableProps) =
                         )}
                       </Box>
                     </TableCell>
-                    <TableCell onClick={e => e.stopPropagation()}>
-                      <PendenciaCell process={process} onProcessClick={onProcessClick} />
+                    <TableCell align='center'>
+                      {process.dueDate ? (
+                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
+                          <CalendarIcon sx={{ fontSize: 16, color: '#8A8D91' }} />
+                          <Typography variant='body2' sx={{ color: '#212121' }}>
+                            {dayjs(process.dueDate).format('DD/MM/YYYY')}
+                          </Typography>
+                        </Box>
+                      ) : (
+                        <Typography variant='body2' sx={{ color: '#8A8D91', textAlign: 'center' }}>—</Typography>
+                      )}
                     </TableCell>
                   </TableRow>
                 );

--- a/src/pages/PlanejamentoContratacao/PlanejamentoContratacaoPage.tsx
+++ b/src/pages/PlanejamentoContratacao/PlanejamentoContratacaoPage.tsx
@@ -1,5 +1,6 @@
 import { Alert, Box, Button, Typography } from '@mui/material';
 import { BusinessCenter as BusinessCenterIcon, Refresh as RefreshIcon } from '@mui/icons-material';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useActiveDepartment } from '@/contexts';
 import { usePlanejamentoDashboard } from '@/hooks/usePlanejamentoDashboard';
@@ -12,7 +13,18 @@ const PlanejamentoContratacaoPage = () => {
   const navigate = useNavigate();
   const { activeDepartment } = useActiveDepartment();
 
-  const { data, isLoading, isError, refetch } = usePlanejamentoDashboard(activeDepartment?._id);
+  const [alertasPage, setAlertasPage] = useState(1);
+  const [alertasLimit, setAlertasLimit] = useState(5);
+  const [recentesPage, setRecentesPage] = useState(1);
+  const [recentesLimit, setRecentesLimit] = useState(5);
+
+  const { data, isLoading, isError, refetch } = usePlanejamentoDashboard({
+    departmentId: activeDepartment?._id,
+    alertasPage,
+    alertasLimit,
+    recentesPage,
+    recentesLimit,
+  });
 
   if (!activeDepartment) {
     return (
@@ -96,8 +108,22 @@ const PlanejamentoContratacaoPage = () => {
         <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', lg: 'row' } }}>
           {/* Coluna esquerda */}
           <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 3 }}>
-            <AlertasCriticos alerts={data?.alertasCriticos} loading={isLoading} />
-            <ProcessosRecentes processes={data?.processosRecentes} loading={isLoading} />
+            <AlertasCriticos
+              data={data?.alertasCriticos}
+              loading={isLoading}
+              page={alertasPage}
+              limit={alertasLimit}
+              onPageChange={setAlertasPage}
+              onLimitChange={(l) => { setAlertasLimit(l); setAlertasPage(1); }}
+            />
+            <ProcessosRecentes
+              data={data?.processosRecentes}
+              loading={isLoading}
+              page={recentesPage}
+              limit={recentesLimit}
+              onPageChange={setRecentesPage}
+              onLimitChange={(l) => { setRecentesLimit(l); setRecentesPage(1); }}
+            />
           </Box>
 
           {/* Sidebar direita */}

--- a/src/pages/PlanejamentoContratacao/components/AlertasCriticos.tsx
+++ b/src/pages/PlanejamentoContratacao/components/AlertasCriticos.tsx
@@ -3,23 +3,42 @@ import {
   BalanceOutlined,
   DrawOutlined,
   InfoOutlined,
-  NotificationsActiveOutlined
+  NotificationsActiveOutlined,
+  ScheduleOutlined
 } from '@mui/icons-material';
-import { Box, Button, Card, Chip, Divider, Skeleton, Typography } from '@mui/material';
+import { Box, Button, Card, Chip, Divider, MenuItem, Pagination, Select, Skeleton, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import type { AlertaCritico } from '@/globals/types';
+import type { AlertaCritico, Paginated } from '@/globals/types';
 
-const ALERT_CONFIG: Record<string, { icon: React.ReactNode; bg: string; color: string }> = {
-  vencido:    { icon: <AccessTimeOutlined sx={{ fontSize: 22 }} />,  bg: 'rgba(186,26,26,0.05)',  color: '#ba1a1a' },
-  assinatura: { icon: <DrawOutlined sx={{ fontSize: 22 }} />,        bg: '#fff7ed',               color: '#ea580c' },
-  juridico:   { icon: <BalanceOutlined sx={{ fontSize: 22 }} />,     bg: '#fefce8',               color: '#ca8a04' },
-  outro:      { icon: <InfoOutlined sx={{ fontSize: 22 }} />,        bg: '#f8fafc',               color: '#64748b' }
+const ALERT_CONFIG: Record<string, { icon: React.ReactNode; bg: string; color: string; btnLabel: string }> = {
+  vencido:        { icon: <AccessTimeOutlined sx={{ fontSize: 22 }} />, bg: 'rgba(186,26,26,0.05)',  color: '#ba1a1a', btnLabel: 'Resolver' },
+  etapa_atrasada: { icon: <ScheduleOutlined sx={{ fontSize: 22 }} />,   bg: 'rgba(234,88,12,0.07)', color: '#ea580c', btnLabel: 'Abrir' },
+  assinatura:     { icon: <DrawOutlined sx={{ fontSize: 22 }} />,       bg: '#fff7ed',               color: '#ea580c', btnLabel: 'Abrir' },
+  juridico:       { icon: <BalanceOutlined sx={{ fontSize: 22 }} />,    bg: '#fefce8',               color: '#ca8a04', btnLabel: 'Abrir' },
+  outro:          { icon: <InfoOutlined sx={{ fontSize: 22 }} />,       bg: '#f8fafc',               color: '#64748b', btnLabel: 'Abrir' },
 };
 
-type Props = { alerts?: AlertaCritico[]; loading: boolean };
+const ALERT_ORDER: AlertaCritico['alertType'][] = ['vencido', 'etapa_atrasada', 'assinatura', 'juridico', 'outro'];
 
-export const AlertasCriticos = ({ alerts, loading }: Props) => {
+const sortAlerts = (alerts: AlertaCritico[]) =>
+  [...alerts].sort((a, b) => ALERT_ORDER.indexOf(a.alertType) - ALERT_ORDER.indexOf(b.alertType));
+
+type Props = {
+  data?: Paginated<AlertaCritico>;
+  loading: boolean;
+  page: number;
+  limit: number;
+  onPageChange: (page: number) => void;
+  onLimitChange: (limit: number) => void;
+};
+
+export const AlertasCriticos = ({ data, loading, page, limit, onPageChange, onLimitChange }: Props) => {
   const navigate = useNavigate();
+  const sorted = sortAlerts(data?.items ?? []);
+  const total = data?.total ?? 0;
+  const totalPages = data?.totalPages ?? 1;
+  const from = total === 0 ? 0 : (page - 1) * limit + 1;
+  const to = Math.min(page * limit, total);
 
   return (
     <Card sx={{ border: '1px solid', borderColor: 'divider', boxShadow: '0 2px 15px -3px rgba(0,0,0,0.07)', overflow: 'hidden' }}>
@@ -30,9 +49,9 @@ export const AlertasCriticos = ({ alerts, loading }: Props) => {
             O que exige sua atenção
           </Typography>
         </Box>
-        {!loading && alerts && alerts.length > 0 && (
+        {!loading && total > 0 && (
           <Chip
-            label={`${alerts.length} Alerta${alerts.length > 1 ? 's' : ''} Crítico${alerts.length > 1 ? 's' : ''}`}
+            label={`${total} Alerta${total > 1 ? 's' : ''} Crítico${total > 1 ? 's' : ''}`}
             size='small'
             sx={{ backgroundColor: 'rgba(186,26,26,0.1)', color: '#ba1a1a', fontWeight: 900, fontSize: '0.625rem', textTransform: 'uppercase', letterSpacing: '0.1em', borderRadius: '999px' }}
           />
@@ -41,19 +60,19 @@ export const AlertasCriticos = ({ alerts, loading }: Props) => {
 
       {loading ? (
         <Box sx={{ p: 2 }}>
-          {Array.from({ length: 3 }).map((_, i) => (
+          {Array.from({ length: limit }).map((_, i) => (
             <Skeleton key={i} variant='rectangular' height={64} sx={{ borderRadius: 1, mb: 1 }} />
           ))}
         </Box>
-      ) : alerts?.length === 0 ? (
+      ) : sorted.length === 0 ? (
         <Box sx={{ px: 4, py: 5, textAlign: 'center' }}>
           <Typography variant='body2' color='text.secondary'>Nenhum alerta crítico no momento</Typography>
         </Box>
       ) : (
-        alerts?.map((alert, idx) => {
+        sorted.map((alert, idx) => {
           const cfg = ALERT_CONFIG[alert.alertType] ?? ALERT_CONFIG.outro;
           return (
-            <Box key={`${alert.processId}-${alert.alertType}`}>
+            <Box key={`${alert.processId}-${alert.alertType}-${idx}`}>
               <Box sx={{ px: 4, py: 2.5, display: 'flex', alignItems: 'center', justifyContent: 'space-between', '&:hover': { backgroundColor: '#fafbfc' }, transition: 'background 0.15s' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5 }}>
                   <Box sx={{ width: 44, height: 44, borderRadius: 2, backgroundColor: cfg.bg, display: 'flex', alignItems: 'center', justifyContent: 'center', color: cfg.color, flexShrink: 0 }}>
@@ -64,7 +83,7 @@ export const AlertasCriticos = ({ alerts, loading }: Props) => {
                       Proc. <Box component='span' sx={{ color: '#1877F2' }}>{alert.processNumber}</Box>
                     </Typography>
                     <Typography sx={{ fontSize: '0.875rem', color: '#64748b', mt: 0.25 }}>
-                      {alert.object} —{' '}
+                      {alert.object && <>{alert.object} — </>}
                       <Box component='span' sx={{ color: cfg.color, fontWeight: 700, textDecoration: 'underline', textDecorationColor: `${cfg.color}50` }}>
                         {alert.description}
                       </Box>
@@ -77,14 +96,42 @@ export const AlertasCriticos = ({ alerts, loading }: Props) => {
                   onClick={() => navigate(`/processos-gerencia/${alert.processId}`)}
                   sx={{ textTransform: 'none', fontWeight: 600, fontSize: '0.875rem', borderRadius: 2, flexShrink: 0, ml: 2, borderColor: cfg.color, color: cfg.color, '&:hover': { backgroundColor: cfg.color, color: '#fff', borderColor: cfg.color } }}
                 >
-                  {alert.alertType === 'vencido' ? 'Resolver' : 'Abrir'}
+                  {cfg.btnLabel}
                 </Button>
               </Box>
-              {idx < (alerts?.length ?? 0) - 1 && <Divider />}
+              {idx < sorted.length - 1 && <Divider />}
             </Box>
           );
         })
       )}
+
+      <Box sx={{ px: 4, py: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2, backgroundColor: '#f8fafc', borderTop: '1px solid #e5e7eb' }}>
+        <Typography variant='body2' sx={{ color: '#6b7280', fontSize: '0.875rem' }}>
+          {total > 0 ? `${from}–${to} de ${total}` : '0 de 0'}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Select
+            value={limit}
+            onChange={(e) => onLimitChange(Number(e.target.value))}
+            size='small'
+            sx={{ height: 32, fontSize: '0.875rem', minWidth: 120 }}
+          >
+            {[5, 10, 25].map((v) => (
+              <MenuItem key={v} value={v}>{v} por página</MenuItem>
+            ))}
+          </Select>
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={(_, p) => onPageChange(p)}
+            variant='outlined'
+            shape='rounded'
+            showFirstButton
+            showLastButton
+            size='small'
+          />
+        </Box>
+      </Box>
     </Card>
   );
 };

--- a/src/pages/PlanejamentoContratacao/components/ProcessosRecentes.tsx
+++ b/src/pages/PlanejamentoContratacao/components/ProcessosRecentes.tsx
@@ -1,32 +1,45 @@
-import { Box, Button, Card, Chip, Skeleton, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
-import dayjs from 'dayjs';
+import { Box, Button, Card, Chip, MenuItem, Pagination, Select, Skeleton, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import type { ProcessoRecente } from '@/globals/types';
+import type { Paginated, ProcessoRecente } from '@/globals/types';
 
-const StatusBadge = ({ status, daysLate, dueDate }: Pick<ProcessoRecente, 'status' | 'daysLate' | 'dueDate'>) => {
-  if (status === 'em_dia') {
-    return <Chip label='Em dia' size='small' sx={{ backgroundColor: 'rgba(0,110,41,0.05)', color: '#006e29', fontWeight: 900, fontSize: '0.625rem', textTransform: 'uppercase', border: '1px solid rgba(0,110,41,0.1)', borderRadius: '999px' }} />;
-  }
-  if (status === 'atrasado') {
-    return <Chip label={`Atrasado (${daysLate}d)`} size='small' sx={{ backgroundColor: 'rgba(186,26,26,0.05)', color: '#ba1a1a', fontWeight: 900, fontSize: '0.625rem', textTransform: 'uppercase', border: '1px solid rgba(186,26,26,0.1)', borderRadius: '999px' }} />;
-  }
-  // prazo
-  return (
-    <Box>
-      <Chip label='Vence em breve' size='small' sx={{ backgroundColor: 'rgba(202,138,4,0.08)', color: '#ca8a04', fontWeight: 900, fontSize: '0.625rem', textTransform: 'uppercase', border: '1px solid rgba(202,138,4,0.15)', borderRadius: '999px' }} />
-      {dueDate && (
-        <Typography sx={{ fontSize: '0.6875rem', color: '#94a3b8', mt: 0.25 }}>
-          {dayjs(dueDate).format('DD/MM/YYYY')}
-        </Typography>
-      )}
-    </Box>
-  );
+const STAGE_STATUS_CONFIG: Record<ProcessoRecente['stageStatus'], { label: string; bg: string; color: string; border: string }> = {
+  em_dia:     { label: 'Em dia',      bg: 'rgba(0,110,41,0.05)',    color: '#006e29', border: 'rgba(0,110,41,0.1)' },
+  atrasada:   { label: 'Atrasada',    bg: 'rgba(186,26,26,0.05)',   color: '#ba1a1a', border: 'rgba(186,26,26,0.1)' },
+  vence_hoje: { label: 'Vence hoje',  bg: 'rgba(202,138,4,0.08)',   color: '#ca8a04', border: 'rgba(202,138,4,0.15)' },
+  concluida:  { label: 'Concluída',   bg: 'rgba(99,102,241,0.07)',  color: '#4f46e5', border: 'rgba(99,102,241,0.15)' },
 };
 
-type Props = { processes?: ProcessoRecente[]; loading: boolean };
+const PROCESS_STATUS_CONFIG: Record<ProcessoRecente['processStatus'], { label: string; bg: string; color: string; border: string }> = {
+  em_andamento: { label: 'Em andamento', bg: 'rgba(24,119,242,0.07)',  color: '#1877F2', border: 'rgba(24,119,242,0.15)' },
+  em_risco:     { label: 'Em risco',     bg: 'rgba(202,138,4,0.08)',   color: '#ca8a04', border: 'rgba(202,138,4,0.15)' },
+  atrasado:     { label: 'Atrasado',     bg: 'rgba(186,26,26,0.05)',   color: '#ba1a1a', border: 'rgba(186,26,26,0.1)' },
+  finalizado:   { label: 'Finalizado',   bg: 'rgba(0,110,41,0.05)',    color: '#006e29', border: 'rgba(0,110,41,0.1)' },
+  paralisado:   { label: 'Paralisado',   bg: 'rgba(100,116,139,0.07)', color: '#475569', border: 'rgba(100,116,139,0.15)' },
+};
 
-export const ProcessosRecentes = ({ processes, loading }: Props) => {
+const StatusChip = ({ cfg }: { cfg: { label: string; bg: string; color: string; border: string } }) => (
+  <Chip
+    label={cfg.label}
+    size='small'
+    sx={{ backgroundColor: cfg.bg, color: cfg.color, fontWeight: 900, fontSize: '0.625rem', textTransform: 'uppercase', border: `1px solid ${cfg.border}`, borderRadius: '999px' }}
+  />
+);
+
+type Props = {
+  data?: Paginated<ProcessoRecente>;
+  loading: boolean;
+  page: number;
+  limit: number;
+  onPageChange: (page: number) => void;
+  onLimitChange: (limit: number) => void;
+};
+
+export const ProcessosRecentes = ({ data, loading, page, limit, onPageChange, onLimitChange }: Props) => {
   const navigate = useNavigate();
+  const total = data?.total ?? 0;
+  const totalPages = data?.totalPages ?? 1;
+  const from = total === 0 ? 0 : (page - 1) * limit + 1;
+  const to = Math.min(page * limit, total);
 
   return (
     <Card sx={{ border: '1px solid', borderColor: 'divider', boxShadow: '0 2px 15px -3px rgba(0,0,0,0.07)', overflow: 'hidden' }}>
@@ -37,7 +50,7 @@ export const ProcessosRecentes = ({ processes, loading }: Props) => {
         <Typography
           component='span'
           onClick={() => navigate('/processos-gerencia')}
-          sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'primary.main', cursor: 'pointer', textTransform: 'none', '&:hover': { textDecoration: 'underline' } }}
+          sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'primary.main', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
         >
           Ver todos
         </Typography>
@@ -50,27 +63,28 @@ export const ProcessosRecentes = ({ processes, loading }: Props) => {
               <TableCell sx={{ pl: 4 }}>Processo</TableCell>
               <TableCell>Objeto</TableCell>
               <TableCell>Etapa Atual</TableCell>
-              <TableCell>Status / Prazo</TableCell>
+              <TableCell>Status da Etapa</TableCell>
+              <TableCell>Status do Processo</TableCell>
               <TableCell align='right' sx={{ pr: 4 }}>Ação</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {loading ? (
-              Array.from({ length: 3 }).map((_, i) => (
+              Array.from({ length: limit }).map((_, i) => (
                 <TableRow key={i}>
-                  {Array.from({ length: 5 }).map((__, j) => (
+                  {Array.from({ length: 6 }).map((__, j) => (
                     <TableCell key={j}><Skeleton variant='text' /></TableCell>
                   ))}
                 </TableRow>
               ))
-            ) : processes?.length === 0 ? (
+            ) : (data?.items.length ?? 0) === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} align='center' sx={{ py: 5 }}>
+                <TableCell colSpan={6} align='center' sx={{ py: 5 }}>
                   <Typography variant='body2' color='text.secondary'>Nenhum processo recente</Typography>
                 </TableCell>
               </TableRow>
             ) : (
-              processes?.map((proc) => (
+              data!.items.map((proc) => (
                 <TableRow
                   key={proc.processId}
                   sx={{ '&:hover': { backgroundColor: '#EBF3FF' }, transition: 'background 0.15s', cursor: 'pointer', '& .MuiTableCell-root': { borderBottom: '1px solid #f1f5f9', py: 2 } }}
@@ -84,12 +98,15 @@ export const ProcessosRecentes = ({ processes, loading }: Props) => {
                   </TableCell>
                   <TableCell>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <Box sx={{ width: 8, height: 8, borderRadius: '50%', flexShrink: 0, backgroundColor: proc.status === 'atrasado' ? '#94a3b8' : proc.status === 'prazo' ? '#ca8a04' : '#1877F2', boxShadow: proc.status === 'em_dia' ? '0 0 0 2px rgba(24,119,242,0.2)' : 'none' }} />
+                      <Box sx={{ width: 8, height: 8, borderRadius: '50%', flexShrink: 0, backgroundColor: STAGE_STATUS_CONFIG[proc.stageStatus].color, opacity: 0.7 }} />
                       <Typography sx={{ fontSize: '0.8125rem', fontWeight: 700, color: '#374151' }}>{proc.currentStage}</Typography>
                     </Box>
                   </TableCell>
                   <TableCell>
-                    <StatusBadge status={proc.status} daysLate={proc.daysLate} dueDate={proc.dueDate} />
+                    <StatusChip cfg={STAGE_STATUS_CONFIG[proc.stageStatus]} />
+                  </TableCell>
+                  <TableCell>
+                    <StatusChip cfg={PROCESS_STATUS_CONFIG[proc.processStatus]} />
                   </TableCell>
                   <TableCell align='right' sx={{ pr: 4 }} onClick={(e) => e.stopPropagation()}>
                     <Button
@@ -107,6 +124,34 @@ export const ProcessosRecentes = ({ processes, loading }: Props) => {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <Box sx={{ px: 4, py: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2, backgroundColor: '#f8fafc', borderTop: '1px solid #e5e7eb' }}>
+        <Typography variant='body2' sx={{ color: '#6b7280', fontSize: '0.875rem' }}>
+          {total > 0 ? `${from}–${to} de ${total}` : '0 de 0'}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Select
+            value={limit}
+            onChange={(e) => onLimitChange(Number(e.target.value))}
+            size='small'
+            sx={{ height: 32, fontSize: '0.875rem', minWidth: 120 }}
+          >
+            {[5, 10, 25].map((v) => (
+              <MenuItem key={v} value={v}>{v} por página</MenuItem>
+            ))}
+          </Select>
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={(_, p) => onPageChange(p)}
+            variant='outlined'
+            shape='rounded'
+            showFirstButton
+            showLastButton
+            size='small'
+          />
+        </Box>
+      </Box>
     </Card>
   );
 };


### PR DESCRIPTION
Add stage-level status and due date support and wire up paginated dashboard responses/UI.

- Types: add Paginated<T>, new fields (stageStatus, stageDueDate) and refined ProcessoRecente/process status enums; update PlanejamentoDashboardResponse to use Paginated for alerts and recent processes.
- API hook: change usePlanejamentoDashboard to accept pagination params (alertasPage/limit, recentesPage/limit) and include them in the request + queryKey.
- UI: display stage due dates and process due dates in FolderProcesses and GerenciaProcesses tables, introduce unified STAGE_STATUS_CONFIG and process-stage chips, simplify alert/late indicators, and use dayjs for date formatting.
- Planejamento page: manage pagination state and pass page/limit handlers to AlertasCriticos and ProcessosRecentes.
- AlertasCriticos & ProcessosRecentes: accept Paginated data, add sorting, totals, page/limit controls (Select + Pagination), and refine badges/labels and empty/loading states.
- Minor styling tweaks: increase sidebar icon sizes and adjust list item icon/text spacing.

These changes enable server-side pagination for dashboard lists and improve visibility of stage-level deadlines and statuses across the UI.